### PR TITLE
fix allowed_hosts settings

### DIFF
--- a/bewelder_redesign/settings.py
+++ b/bewelder_redesign/settings.py
@@ -25,8 +25,10 @@ SECRET_KEY = 'vd0l%=zj66k$^ob5zdwwvxmfiiop198scrjbh*16*2^y(h=xra'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(os.environ.get('DJANGO_DEBUG', True))
 
-# ALLOWED_HOSTS = ['bewgb.ru', 'bewgb.local']
-ALLOWED_HOSTS = ['127.0.0.1']
+if DEBUG:
+    ALLOWED_HOSTS = []
+else:
+    ALLOWED_HOSTS = ['bewgb.ru', 'bewgb.local']
 
 
 # Application definition


### PR DESCRIPTION
Исправление, избавляющее от ручного переопределения ALLOWED_HOSTS для дев/прод окружения.