### PR TITLE
Начальная реализация резюме

### DIFF
--- a/bewelder_redesign/settings.py
+++ b/bewelder_redesign/settings.py
@@ -129,7 +129,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = 'static'
+# STATIC_ROOT = 'static'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, "static"),
 )

--- a/bewelder_redesign/urls.py
+++ b/bewelder_redesign/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('users/', include('users.urls', namespace='users')),
     path('vacancies/', include('vacancies.urls', namespace='vacancies')),
     path('orgs/', include('orgs.urls', namespace='orgs')),
+    path('resumes/', include('resumes.urls', namespace='resumes')),
     path('', mainapp.main, name='main')
 ]
 if settings.DEBUG:

--- a/bewelder_redesign/urls.py
+++ b/bewelder_redesign/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     path('vacancies/', include('vacancies.urls', namespace='vacancies')),
     path('orgs/', include('orgs.urls', namespace='orgs')),
     path('resumes/', include('resumes.urls', namespace='resumes')),
-    path('', mainapp.main, name='main')
+    path('', include('mainapp.urls', namespace='mainapp'))
 ]
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/mainapp/templates/mainapp/includes/top-header.html
+++ b/mainapp/templates/mainapp/includes/top-header.html
@@ -2,7 +2,8 @@
 <div class="cont-width-block">
     <div class="row align-items-center py-5">
         <div class="col-sm-6 col-md-4 col-xl-3">
-            <div class="top-header-logo pb-3"><a href="{% url 'mainapp:home' %}"><img src="{% static 'img/BEWELDER_RU_logo.png' %}" alt="bewelder_logo"></a></div>
+            <div class="top-header-logo pb-3"><a href="{% url 'mainapp:home' %}"><img src="{% static 'img/BEWELDER_RU_logo.png' %}"
+                        alt="bewelder_logo"></a></div>
         </div>
         <div class="col-sm-6 col-md-2 col-xl-2">
             <div class="top-header-region-select-text">
@@ -21,13 +22,15 @@
             </div>
 
         </div>
-        <div class="col-xs-12 col-sm-6 offset-lg-3 col-lg-3 offset-xl-0 col-xl-2"><div class="btn btn-light w-100 my-2">
-            Личный кабинет
-        </div></div>
+        <div class="col-xs-12 col-sm-6 offset-lg-3 col-lg-3 offset-xl-0 col-xl-2">
+            <a href="{% url 'mainapp:settings' %}" class="btn btn-light w-100 my-2">
+                Личный кабинет
+            </a>
+        </div>
         <div class="col-xs-12 col-sm-6 col-lg-3 col-xl-2">
             <a href="{% url 'users:registration' %}" class="btn btn-primary w-100">
                 Регистрация
             </a>
         </div>
-        </div>
     </div>
+</div>

--- a/mainapp/templates/mainapp/includes/top-header.html
+++ b/mainapp/templates/mainapp/includes/top-header.html
@@ -2,7 +2,7 @@
 <div class="cont-width-block">
     <div class="row align-items-center py-5">
         <div class="col-sm-6 col-md-4 col-xl-3">
-            <div class="top-header-logo pb-3"><a href="{% url 'main' %}"><img src="{% static 'img/BEWELDER_RU_logo.png' %}" alt="bewelder_logo"></a></div>
+            <div class="top-header-logo pb-3"><a href="{% url 'mainapp:home' %}"><img src="{% static 'img/BEWELDER_RU_logo.png' %}" alt="bewelder_logo"></a></div>
         </div>
         <div class="col-sm-6 col-md-2 col-xl-2">
             <div class="top-header-region-select-text">

--- a/mainapp/templates/mainapp/index.html
+++ b/mainapp/templates/mainapp/index.html
@@ -89,4 +89,23 @@
         </div>
     </div>
 </div>
+
+{% if resumes %}
+<div class="container h-100 my-5">
+    <div class="row justify-content-center">
+        <div class="col">
+            <h3>Новые резюме</h3>
+            {% for resume in resumes %}
+            {% include 'components/resume_short.html' %}
+            {% endfor %}
+            <a href="{% url 'resumes:resume_list' %}" class="btn
+            btn-secondary mx-5 px-5">Просмотреть все резюме</a>
+            
+        </div>
+    </div>
+    
+</div>
+{% endif %}
+
+
 {% endblock %}

--- a/mainapp/templates/mainapp/settings.html
+++ b/mainapp/templates/mainapp/settings.html
@@ -1,0 +1,34 @@
+{% extends 'mainapp/base.html' %}
+
+{% block content %}
+<div class="container my-5">
+    <h3>
+        Ваши данные
+    </h3>
+    <hr>
+    <div>
+        <p>
+            {{ user.get_full_name }}<br>
+            {{ user.email }}<br>
+            {{ user.date_of_birth|default:'' }}
+        </p>
+        <a href="{% url 'users:profile_update' %}" class="btn
+        btn-outline-success mt-3">Изменить данные</a>
+    </div>
+    {% with resume=user.resume %}
+    {% if resume %}
+    <div class="my-5">
+        <h4>Ваше резюме</h4>
+        <hr>
+        {% include 'components/resume_full.html' %}
+        <a href="{% url 'resumes:resume_update' %}" class="btn
+        btn-outline-success">Обновить резюме</a>
+    </div>
+    {% else %}
+    <div class="my-5">
+        <a href="{% url 'resumes:resume_create' %}">Создать резюме</a>
+    </div>
+    {% endif %}
+    {% endwith %}
+</div>
+{% endblock %}

--- a/mainapp/urls.py
+++ b/mainapp/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from mainapp import views
+
+
+app_name = 'mainapp'
+urlpatterns = [
+    path('', views.HomePageView.as_view(), name='home'),
+]

--- a/mainapp/urls.py
+++ b/mainapp/urls.py
@@ -5,5 +5,6 @@ from mainapp import views
 
 app_name = 'mainapp'
 urlpatterns = [
+    path('settings/', views.UserSettingsView.as_view(), name='settings'),
     path('', views.HomePageView.as_view(), name='home'),
 ]

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -1,7 +1,21 @@
 from django.shortcuts import render
+from django.views.generic import TemplateView
+
+from resumes.models import Resume
+
+
+
+class HomePageView(TemplateView):
+    template_name = 'mainapp/index.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['resumes'] = Resume.objects.all()[:5]
+        return context
+
 
 # Create your views here.
 
-def main(request):
-    title = 'Bewelder learning project'
-    return render(request, 'mainapp/index.html', context={'title': title})
+# def main(request):
+#     title = 'Bewelder learning project'
+#     return render(request, 'mainapp/index.html', context={'title': title})

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -1,8 +1,12 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import render
 from django.views.generic import TemplateView
 
 from resumes.models import Resume
 
+
+User = get_user_model()
 
 
 class HomePageView(TemplateView):
@@ -11,6 +15,15 @@ class HomePageView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['resumes'] = Resume.objects.all()[:5]
+        return context
+
+
+class UserSettingsView(LoginRequiredMixin, TemplateView):
+    template_name = 'mainapp/settings.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # something
         return context
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pillow==5.4.1
 python-memcached==1.59
 pytz==2018.9              # via django
 six==1.12.0               # via python-memcached
+mixer==6.1.3

--- a/resumes/admin.py
+++ b/resumes/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
 
-# Register your models here.
+from resumes.models import Resume
+
+
+admin.site.register(Resume)

--- a/resumes/forms.py
+++ b/resumes/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from resumes.models import Resume
+
+
+class ResumeForm(forms.ModelForm):
+    class Meta:
+        model = Resume
+        exclude = ('user',)

--- a/resumes/models.py
+++ b/resumes/models.py
@@ -17,3 +17,26 @@ class Resume(models.Model):
 
     def __str__(self):
         return 'Резюме: {} {}'.format(self.position.lower(), self.user.get_full_name())
+    
+    @property
+    def salary(self):
+        if self.salary_min and self.salary_max:
+            return '{}-{}'.format(self.salary_min, self.salary_max)
+        elif self.salary_min:
+            return 'от {}'.format(self.salary_min)
+        elif self.salary_max:
+            return 'до {}'.format(self.salary_max)
+        else:
+            return ''
+
+    @property
+    def experience_str(self):
+        if not self.experience:
+            return '0 лет'
+        mod = self.experience % 10
+        if mod == 1 and self.experience != 11:
+            return '{} год'.format(self.experience)
+        elif 1 < mod < 5 and (self.experience < 10 or self.experience > 20):
+            return '{} года'.format(self.experience)
+        
+        return '{} лет'.format(self.experience)

--- a/resumes/models.py
+++ b/resumes/models.py
@@ -1,3 +1,15 @@
+from django.contrib.auth import get_user_model
 from django.db import models
 
-# Create your models here.
+
+class Resume(models.Model):
+    user = models.OneToOneField(get_user_model(), on_delete=models.CASCADE)
+    position = models.CharField(max_length=255)
+    salary_min = models.IntegerField(null=True, blank=True)
+    salary_max = models.IntegerField(null=True, blank=True)
+    experience = models.IntegerField(null=True, blank=True)
+    about = models.TextField(null=True, blank=True)
+    city = models.CharField(max_length=100, null=True, blank=True)
+
+    def __str__(self):
+        return 'Резюме: {} {}'.format(self.position.lower(), self.user.get_full_name())

--- a/resumes/models.py
+++ b/resumes/models.py
@@ -3,13 +3,17 @@ from django.db import models
 
 
 class Resume(models.Model):
-    user = models.OneToOneField(get_user_model(), on_delete=models.CASCADE)
-    position = models.CharField(max_length=255)
-    salary_min = models.IntegerField(null=True, blank=True)
-    salary_max = models.IntegerField(null=True, blank=True)
-    experience = models.IntegerField(null=True, blank=True)
-    about = models.TextField(null=True, blank=True)
-    city = models.CharField(max_length=100, null=True, blank=True)
+    user = models.OneToOneField(get_user_model(), on_delete=models.CASCADE, verbose_name='пользователь')
+    position = models.CharField('Должность', max_length=255)
+    salary_min = models.PositiveIntegerField('Зарплата от', null=True, blank=True)
+    salary_max = models.PositiveIntegerField('Зарплата до', null=True, blank=True)
+    experience = models.PositiveIntegerField('Стаж', null=True, blank=True)
+    about = models.TextField('О себе', null=True, blank=True)
+    city = models.CharField('Место работы (город)', max_length=100, null=True, blank=True)
+
+    class Meta:
+        verbose_name = 'резюме'
+        verbose_name_plural = 'резюме'
 
     def __str__(self):
         return 'Резюме: {} {}'.format(self.position.lower(), self.user.get_full_name())

--- a/resumes/models.py
+++ b/resumes/models.py
@@ -10,10 +10,13 @@ class Resume(models.Model):
     experience = models.PositiveIntegerField('Стаж', null=True, blank=True)
     about = models.TextField('О себе', null=True, blank=True)
     city = models.CharField('Место работы (город)', max_length=100, null=True, blank=True)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = 'резюме'
         verbose_name_plural = 'резюме'
+        ordering = ['-created']
 
     def __str__(self):
         return 'Резюме: {} {}'.format(self.position.lower(), self.user.get_full_name())

--- a/resumes/models.py
+++ b/resumes/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.db import models
+from django.urls import reverse
 
 
 class Resume(models.Model):
@@ -43,3 +44,6 @@ class Resume(models.Model):
             return '{} года'.format(self.experience)
         
         return '{} лет'.format(self.experience)
+
+    def get_absolute_url(self):
+        return reverse('resumes:resume_detail', kwargs={'pk':self.id})

--- a/resumes/templates/components/resume_full.html
+++ b/resumes/templates/components/resume_full.html
@@ -1,0 +1,24 @@
+<h3>{{ resume.user.get_full_name|title }}</h3>
+<p>
+    Должность: {{ resume.position }}<br>
+
+    {% if resume.salary %}
+    Зарплата:
+    {{ resume.salary }}<br>
+    {% endif %}
+
+    {% if resume.experience %}
+    Стаж: {{ resume.experience_str }}<br>
+    {% endif %}
+
+    {% if resume.city %}
+    Город: {{ resume.city|title }}<br>
+    {% endif %}
+</p>
+
+{% if resume.about %}
+<h4>О себе</h4>
+<p>
+    {{ resume.about|linebreaks }}
+</p>
+{% endif %}

--- a/resumes/templates/components/resume_short.html
+++ b/resumes/templates/components/resume_short.html
@@ -1,0 +1,25 @@
+<div class="card my-3">
+    <div class="card-header">{{ resume.position }}</div>
+    <div class="card-body">
+        <h5 class="card-title">
+            {{ resume.user.get_full_name|title }}
+        </h5>
+        {% if resume.salary %}
+        <div class="card-subtitle mb-2 text-muted">
+            Зарплата: {{ resume.salary }}
+        </div>
+        {% endif %}
+        {% if resume.city %}
+        <div class="card-subtitle mb-2 text-muted">
+            Место работы: {{ resume.city }}
+        </div>
+        {% endif %}
+        {% if resume.about %}
+        <p class="card-text">
+            {{ resume.about|linebreaks|truncatewords:10 }}
+        </p>
+        {% endif %}
+        <a href="{% url 'resumes:resume_detail' pk=resume.id %}" class="btn btn-primary">Подробнее</a>
+
+    </div>
+</div>

--- a/resumes/templates/components/resume_short.html
+++ b/resumes/templates/components/resume_short.html
@@ -19,7 +19,7 @@
             {{ resume.about|linebreaks|truncatewords:10 }}
         </p>
         {% endif %}
-        <a href="{% url 'resumes:resume_detail' pk=resume.id %}" class="btn btn-primary">Подробнее</a>
+        <a href="{% url 'resumes:resume_detail' pk=resume.id %}" class="card-link">Подробнее...</a>
 
     </div>
 </div>

--- a/resumes/templates/resumes/resume_detail.html
+++ b/resumes/templates/resumes/resume_detail.html
@@ -1,0 +1,31 @@
+{% extends 'mainapp/base.html' %}
+
+{% block content %}
+<div class="container my-5">
+    <h3>{{ resume.user.get_full_name|title }}</h3>
+    <p>
+        Должность: {{ resume.position }}<br>
+
+        {% if resume.salary %}
+        Зарплата:
+        {{ resume.salary }}<br>
+        {% endif %}
+
+        {% if resume.experience %}
+        Стаж: {{ resume.experience_str }}<br>
+        {% endif %}
+
+        {% if resume.city %}
+        Город: {{ resume.city|title }}<br>
+        {% endif %}
+    </p>
+
+    {% if resume.about %}
+    <h4>О себе</h4>
+    <p>
+        {{ resume.about|linebreaks }}
+    </p>
+    {% endif %}
+    <input type=button value="Назад" onClick="javascript:history.go(-1);" class="btn btn-primary">
+</div>
+{% endblock %}

--- a/resumes/templates/resumes/resume_detail.html
+++ b/resumes/templates/resumes/resume_detail.html
@@ -2,30 +2,7 @@
 
 {% block content %}
 <div class="container my-5">
-    <h3>{{ resume.user.get_full_name|title }}</h3>
-    <p>
-        Должность: {{ resume.position }}<br>
-
-        {% if resume.salary %}
-        Зарплата:
-        {{ resume.salary }}<br>
-        {% endif %}
-
-        {% if resume.experience %}
-        Стаж: {{ resume.experience_str }}<br>
-        {% endif %}
-
-        {% if resume.city %}
-        Город: {{ resume.city|title }}<br>
-        {% endif %}
-    </p>
-
-    {% if resume.about %}
-    <h4>О себе</h4>
-    <p>
-        {{ resume.about|linebreaks }}
-    </p>
-    {% endif %}
+    {% include 'components/resume_full.html' %}
     <input type=button value="Назад" onClick="javascript:history.go(-1);" class="btn btn-primary">
 </div>
 {% endblock %}

--- a/resumes/templates/resumes/resume_form.html
+++ b/resumes/templates/resumes/resume_form.html
@@ -1,0 +1,14 @@
+{% extends 'mainapp/base.html' %}
+
+{% block content %}
+<div class="m-5">
+    <h5>Резюме</h5>
+    <h2>{{ user.get_full_name|title }}</h2>
+    <form method="post" class="my-3">
+        {% csrf_token %}
+        {% include 'includes/bootstrap_form.html' %}
+        <input type="submit" value="Создать" class="btn btn-success">
+    </form>
+</div>
+
+{% endblock %}

--- a/resumes/templates/resumes/resume_list.html
+++ b/resumes/templates/resumes/resume_list.html
@@ -33,5 +33,25 @@
     <p>Нет резюме</p>
     {% endfor %}
 
+
+    {% if is_paginated %}
+    <ul class="pagination">
+        {% if page_obj.has_previous %}
+        <li class="page-item"><a class="page-link" href="{% url 'resumes:resume_list' %}?page={{ page_obj.previous_page_number }}"><i
+                    class="fa fa-arrow-left"></i></a></li>
+        {% endif %}
+        {% for page in page_obj.paginator.page_range %}
+        {% if page == page_obj.number %}
+        <li class="page-item"><a class="page-link text-dark" href="{% url 'resumes:resume_list' %}?page={{ page }}">{{ page }}</a></li>
+        {% else %}
+        <li class="page-item"><a class="page-link" href="{% url 'resumes:resume_list' %}?page={{ page }}">{{ page }}</a></li>
+        {% endif %}
+        {% endfor %}
+        {% if page_obj.has_next %}
+        <li class="page-item"><a class="page-link" href="{% url 'resumes:resume_list' %}?page={{ page_obj.next_page_number }}"><i
+                    class="fa fa-arrow-right"></i></a></li>
+        {% endif %}
+    </ul>
+    {% endif %}
 </div>
 {% endblock %}

--- a/resumes/templates/resumes/resume_list.html
+++ b/resumes/templates/resumes/resume_list.html
@@ -1,0 +1,37 @@
+{% extends 'mainapp/base.html' %}
+
+{% block content %}
+<div class="container my-5">
+    <h3 class="mb-5">Резюме</h3>
+    {% for resume in resumes %}
+    <div class="card my-3">
+        <div class="card-header">{{ resume.position }}</div>
+        <div class="card-body">
+            <h5 class="card-title">
+                {{ resume.user.get_full_name|title }}
+            </h5>
+            {% if resume.salary %}
+            <div class="card-subtitle mb-2 text-muted">
+                Зарплата: {{ resume.salary }}
+            </div>
+            {% endif %}
+            {% if resume.city %}
+            <div class="card-subtitle mb-2 text-muted">
+                Место работы: {{ resume.city }}
+            </div>
+            {% endif %}
+            {% if resume.about %}
+            <p class="card-text">
+                {{ resume.about|linebreaks|truncatewords:10 }}
+            </p>
+            {% endif %}
+            <a href="{% url 'resumes:resume_detail' pk=resume.id %}" class="btn btn-primary">Подробнее</a>
+
+        </div>
+    </div>
+    {% empty %}
+    <p>Нет резюме</p>
+    {% endfor %}
+
+</div>
+{% endblock %}

--- a/resumes/templates/resumes/resume_list.html
+++ b/resumes/templates/resumes/resume_list.html
@@ -4,31 +4,7 @@
 <div class="container my-5">
     <h3 class="mb-5">Резюме</h3>
     {% for resume in resumes %}
-    <div class="card my-3">
-        <div class="card-header">{{ resume.position }}</div>
-        <div class="card-body">
-            <h5 class="card-title">
-                {{ resume.user.get_full_name|title }}
-            </h5>
-            {% if resume.salary %}
-            <div class="card-subtitle mb-2 text-muted">
-                Зарплата: {{ resume.salary }}
-            </div>
-            {% endif %}
-            {% if resume.city %}
-            <div class="card-subtitle mb-2 text-muted">
-                Место работы: {{ resume.city }}
-            </div>
-            {% endif %}
-            {% if resume.about %}
-            <p class="card-text">
-                {{ resume.about|linebreaks|truncatewords:10 }}
-            </p>
-            {% endif %}
-            <a href="{% url 'resumes:resume_detail' pk=resume.id %}" class="btn btn-primary">Подробнее</a>
-
-        </div>
-    </div>
+        {% include 'components/resume_short.html' %}
     {% empty %}
     <p>Нет резюме</p>
     {% endfor %}

--- a/resumes/tests.py
+++ b/resumes/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/resumes/tests/test_forms.py
+++ b/resumes/tests/test_forms.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+
+from resumes.forms import ResumeForm
+
+
+class ResumeFormTestCase(TestCase):
+    def test_exclude_user_field(self):
+        form = ResumeForm()
+        self.assertNotIn('user', form.fields.keys())

--- a/resumes/tests/test_models.py
+++ b/resumes/tests/test_models.py
@@ -1,16 +1,51 @@
-from django.test import TestCase
+import itertools
+
 from django.contrib.auth import get_user_model
+from django.test import TestCase
 
 from resumes.models import Resume
-
 
 User = get_user_model()
 
 
 class ResumeTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create_user('foo@bar.com', first_name='Иван', last_name='Иванов')
+
     def test_str_resume(self):
-        user = User.objects.create_user('foo@bar.com', first_name='Иван', last_name='Иванов')
+        user = User.objects.first()
         resume = Resume.objects.create(user=user, position='Сварщик')
         expected = 'Резюме: сварщик Иван Иванов'
         result = str(resume)
         self.assertEqual(expected, result)
+
+    def test_salary_property(self):
+        user = User.objects.first()
+        resume = Resume.objects.create(user=user, position='Сварщик')
+        self.assertEqual(resume.salary, '')
+        resume.salary_min = 50000
+        self.assertEqual(resume.salary, 'от 50000')
+        resume.salary_max = 100000
+        self.assertEqual(resume.salary, '50000-100000')
+        resume.salary_min = 0
+        self.assertEqual(resume.salary, 'до 100000')
+
+    def test_experience_str(self):
+        user = User.objects.first()
+        resume = Resume.objects.create(user=user, position='Сварщик')
+        self.assertEqual(resume.experience_str, '0 лет')
+        for i, exp in ((1, '1 год'), (21, '21 год'), (31, '31 год')):
+            resume.experience = i
+            with self.subTest(i=i):
+                self.assertEqual(resume.experience_str, exp)
+        
+        for i in itertools.chain(range(5, 21), range(25, 31), range(35, 41)):
+            resume.experience = i
+            with self.subTest(i=i):
+                self.assertEqual(resume.experience_str, '{} лет'.format(i))
+
+        for i in itertools.chain(range(2, 5), range(22, 25), range(32, 35)):
+            resume.experience = i
+            with self.subTest(i=i):
+                self.assertEqual(resume.experience_str, '{} года'.format(i))

--- a/resumes/tests/test_models.py
+++ b/resumes/tests/test_models.py
@@ -9,43 +9,42 @@ User = get_user_model()
 
 
 class ResumeTestCase(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        User.objects.create_user('foo@bar.com', first_name='Иван', last_name='Иванов')
+    def setUp(self):
+        self.user = User.objects.create_user('foo@bar.com', first_name='Иван', last_name='Иванов')
+        self.resume = Resume.objects.create(user=self.user, position='Сварщик')
+        
 
     def test_str_resume(self):
-        user = User.objects.first()
-        resume = Resume.objects.create(user=user, position='Сварщик')
         expected = 'Резюме: сварщик Иван Иванов'
-        result = str(resume)
+        result = str(self.resume)
         self.assertEqual(expected, result)
 
     def test_salary_property(self):
-        user = User.objects.first()
-        resume = Resume.objects.create(user=user, position='Сварщик')
-        self.assertEqual(resume.salary, '')
-        resume.salary_min = 50000
-        self.assertEqual(resume.salary, 'от 50000')
-        resume.salary_max = 100000
-        self.assertEqual(resume.salary, '50000-100000')
-        resume.salary_min = 0
-        self.assertEqual(resume.salary, 'до 100000')
+        self.assertEqual(self.resume.salary, '')
+        self.resume.salary_min = 50000
+        self.assertEqual(self.resume.salary, 'от 50000')
+        self.resume.salary_max = 100000
+        self.assertEqual(self.resume.salary, '50000-100000')
+        self.resume.salary_min = 0
+        self.assertEqual(self.resume.salary, 'до 100000')
 
     def test_experience_str(self):
-        user = User.objects.first()
-        resume = Resume.objects.create(user=user, position='Сварщик')
-        self.assertEqual(resume.experience_str, '0 лет')
+        self.assertEqual(self.resume.experience_str, '0 лет')
         for i, exp in ((1, '1 год'), (21, '21 год'), (31, '31 год')):
-            resume.experience = i
+            self.resume.experience = i
             with self.subTest(i=i):
-                self.assertEqual(resume.experience_str, exp)
+                self.assertEqual(self.resume.experience_str, exp)
         
         for i in itertools.chain(range(5, 21), range(25, 31), range(35, 41)):
-            resume.experience = i
+            self.resume.experience = i
             with self.subTest(i=i):
-                self.assertEqual(resume.experience_str, '{} лет'.format(i))
+                self.assertEqual(self.resume.experience_str, '{} лет'.format(i))
 
         for i in itertools.chain(range(2, 5), range(22, 25), range(32, 35)):
-            resume.experience = i
+            self.resume.experience = i
             with self.subTest(i=i):
-                self.assertEqual(resume.experience_str, '{} года'.format(i))
+                self.assertEqual(self.resume.experience_str, '{} года'.format(i))
+
+    def test_get_absolute_url(self):
+        result = self.resume.get_absolute_url()
+        self.assertEqual(result, '/resumes/{}'.format(self.resume.id))

--- a/resumes/tests/test_models.py
+++ b/resumes/tests/test_models.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from resumes.models import Resume
+
+
+User = get_user_model()
+
+
+class ResumeTestCase(TestCase):
+    def test_str_resume(self):
+        user = User.objects.create_user('foo@bar.com', first_name='Иван', last_name='Иванов')
+        resume = Resume.objects.create(user=user, position='Сварщик')
+        expected = 'Резюме: сварщик Иван Иванов'
+        result = str(resume)
+        self.assertEqual(expected, result)

--- a/resumes/tests/test_views.py
+++ b/resumes/tests/test_views.py
@@ -1,0 +1,29 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from mixer.backend.django import mixer
+
+from resumes.models import Resume
+
+User = get_user_model()
+
+
+class ResumeListViewTestCase(TestCase):
+    def test_resume_list_pagination(self):
+        mixer.cycle(15).blend(Resume)
+        resumes = [repr(r) for r in Resume.objects.all()[:10]]
+        url = reverse('resumes:resume_list')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.context_data['is_paginated'])
+        self.assertQuerysetEqual(resp.context.get('resumes'), resumes)
+
+
+class ResumeDetailViewTestCase(TestCase):
+    def test_resume_detail_view(self):
+        resume = mixer.blend(Resume)
+        url = reverse('resumes:resume_detail', kwargs={'pk': resume.id})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context.get('resume'), resume)

--- a/resumes/tests/test_views.py
+++ b/resumes/tests/test_views.py
@@ -5,11 +5,12 @@ from django.urls import reverse
 from mixer.backend.django import mixer
 
 from resumes.models import Resume
+from resumes.forms import ResumeForm
 
 User = get_user_model()
 
 
-class ResumeListViewTestCase(TestCase):
+class ResumeListTestCase(TestCase):
     def test_resume_list_pagination(self):
         mixer.cycle(15).blend(Resume)
         resumes = [repr(r) for r in Resume.objects.all()[:10]]
@@ -20,10 +21,54 @@ class ResumeListViewTestCase(TestCase):
         self.assertQuerysetEqual(resp.context.get('resumes'), resumes)
 
 
-class ResumeDetailViewTestCase(TestCase):
+class ResumeDetailTestCase(TestCase):
     def test_resume_detail_view(self):
         resume = mixer.blend(Resume)
         url = reverse('resumes:resume_detail', kwargs={'pk': resume.id})
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.context.get('resume'), resume)
+
+
+class ResumeCreateTestCase(TestCase):
+    url_name = 'resumes:resume_create'
+
+    def test_with_unauthorized(self):
+        resp = self.client.get(reverse(self.url_name))
+        self.assertRedirects(
+            resp,
+            '{}?next={}'.format(reverse('users:login'), reverse(self.url_name))
+        )
+
+    def test_user_has_resume_redirects_to_update(self):
+        username = 'foo@bar.com'
+        password = 'geekbrains'
+        user = User.objects.create_user(username, password)
+        resume = mixer.blend(Resume, user=user)
+        self.client.login(username=username, password=password)
+        resp = self.client.get(reverse(self.url_name))
+        self.assertRedirects(
+            resp,
+            reverse('resumes:resume_update')
+        )
+
+    def test_create_resume(self):
+        username = 'foo@bar.com'
+        password = 'geekbrains'
+        user = User.objects.create_user(username, password)
+        self.client.login(username=username, password=password)
+        resp = self.client.get(reverse(self.url_name))
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, 'resumes/resume_form.html')
+        self.assertFalse(hasattr(user, 'resume'))
+        self.assertIsInstance(resp.context['form'], ResumeForm)
+
+        data = {
+            'position': 'welder',
+            'salary_min': 10000,
+        }
+        resp = self.client.post(reverse(self.url_name), data=data, follow=True)
+        self.assertRedirects(resp, reverse('resumes:resume_detail', args=[resp.context['resume'].pk]))
+        user.refresh_from_db()
+        self.assertTrue(hasattr(user, 'resume'))
+        self.assertTrue(resp.context['resume'], user.resume)

--- a/resumes/urls.py
+++ b/resumes/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from resumes import views
+
+app_name = 'resumes'
+urlpatterns = [
+    path('<int:pk>', views.ResumeDetail.as_view(), name='resume_detail'),
+    path('', views.ResumeList.as_view(), name='resume_list'),
+
+]

--- a/resumes/urls.py
+++ b/resumes/urls.py
@@ -5,6 +5,8 @@ from resumes import views
 app_name = 'resumes'
 urlpatterns = [
     path('<int:pk>', views.ResumeDetail.as_view(), name='resume_detail'),
+    path('create/', views.ResumeCreate.as_view(), name='resume_create'),
+    path('update/', views.ResumeUpdate.as_view(), name='resume_update'),
     path('', views.ResumeList.as_view(), name='resume_list'),
 
 ]

--- a/resumes/views.py
+++ b/resumes/views.py
@@ -1,5 +1,8 @@
-from django.views.generic import ListView, DetailView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import redirect
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
+from resumes.forms import ResumeForm
 from resumes.models import Resume
 
 
@@ -12,3 +15,27 @@ class ResumeList(ListView):
 class ResumeDetail(DetailView):
     model = Resume
     context_object_name = 'resume'
+
+
+class ResumeCreate(LoginRequiredMixin, CreateView):
+    form_class = ResumeForm
+    template_name = 'resumes/resume_form.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        user = request.user
+        if hasattr(user, 'resume') and user.resume.id:
+            return redirect('resumes:resume_update')
+        return super().dispatch(request, *args, **kwargs)
+
+    def form_valid(self, form):
+        resume = form.save(commit=False)
+        resume.user = self.request.user
+        resume.save()
+        return redirect('resumes:resume_detail', pk=resume.id)
+
+
+class ResumeUpdate(LoginRequiredMixin, UpdateView):
+    form_class = ResumeForm
+
+    def get_object(self, queryset=None):
+        return self.request.user.resume

--- a/resumes/views.py
+++ b/resumes/views.py
@@ -1,3 +1,14 @@
-from django.shortcuts import render
+from django.views.generic import ListView, DetailView
 
-# Create your views here.
+from resumes.models import Resume
+
+
+class ResumeList(ListView):
+    model = Resume
+    paginate_by = 10
+    context_object_name = 'resumes'
+
+
+class ResumeDetail(DetailView):
+    model = Resume
+    context_object_name = 'resume'

--- a/users/models.py
+++ b/users/models.py
@@ -8,7 +8,7 @@ from django.db import models
 class UserManager(BaseUserManager):
     def create_user(self, email, password=None, first_name='', last_name='',
                     date_of_birth=None, is_active=True, is_staff=False, is_superuser=False,
-                    is_seeker=False, is_employer=False):
+                    is_employer=False):
         """ Create and save user. """
         if not email:
             raise ValueError('User must have an email address')
@@ -20,7 +20,6 @@ class UserManager(BaseUserManager):
             is_active = is_active,
             is_staff = is_staff,
             is_superuser = is_superuser,
-            is_seeker = is_seeker,
             is_employer = is_employer,
         )
         user.set_password(password)
@@ -56,7 +55,6 @@ class User(AbstractBaseUser, PermissionsMixin):
     is_superuser = models.BooleanField(default=False)
 
     is_employer = models.BooleanField(default=False)
-    is_seeker = models.BooleanField(default=False)
 
     USERNAME_FIELD = 'email'
     EMAIL_FIELD = 'email'
@@ -67,6 +65,10 @@ class User(AbstractBaseUser, PermissionsMixin):
     class Meta:
         verbose_name = 'пользователь'
         verbose_name_plural = 'пользователи'
+
+    @property
+    def is_seeker(self):
+        return hasattr(self, 'resume') and bool(self.resume.id)
 
     def clean(self):
         super().clean()

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from users.models import User, UserManager
+from resumes.models import Resume
 
 
 class UserManagerTestCase(TestCase):
@@ -41,3 +42,13 @@ class UserTestCase(TestCase):
     def test_user_get_short_name(self):
         user = User(email='foo@bar.com', first_name='Иван', last_name='Иванов')
         self.assertEqual(user.get_short_name(), 'Иван И.')
+
+    def test_user_is_seeker(self):
+        user = User.objects.create_user('foo@bar.com', 'password')
+        self.assertFalse(user.is_seeker)
+
+        resume = Resume.objects.create(user=user, position='welder')
+        self.assertTrue(user.is_seeker)
+
+        resume.delete()
+        self.assertFalse(user.is_seeker)

--- a/users/views.py
+++ b/users/views.py
@@ -17,7 +17,7 @@ class UserUpdateView(LoginRequiredMixin, generic.UpdateView):
     model = User
     template_name = 'users/profile_update.html'
     fields = 'first_name', 'last_name', 'email', 'date_of_birth'
-    success_url = reverse_lazy('mainapp:home')
+    success_url = reverse_lazy('mainapp:settings')
     
     def get_object(self):
         return self.request.user

--- a/users/views.py
+++ b/users/views.py
@@ -17,7 +17,7 @@ class UserUpdateView(LoginRequiredMixin, generic.UpdateView):
     model = User
     template_name = 'users/profile_update.html'
     fields = 'first_name', 'last_name', 'email', 'date_of_birth'
-    success_url = reverse_lazy('main')
+    success_url = reverse_lazy('mainapp:home')
     
     def get_object(self):
         return self.request.user

--- a/users_resume_dump.json
+++ b/users_resume_dump.json
@@ -1,0 +1,1334 @@
+[
+{
+  "model": "users.user",
+  "pk": "22242431-d4c7-452c-8340-be143ca10563",
+  "fields": {
+    "password": "suXHDYosGScSAxdLIDCJ",
+    "last_login": null,
+    "email": "pearsonkatie@yahoo.com",
+    "first_name": "Mary",
+    "last_name": "Todd",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.277Z",
+    "updated": "2019-01-24T17:00:20.277Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "25db6356-51c9-470f-904c-eaedd8b8b6c3",
+  "fields": {
+    "password": "qVmiXQNghsaoBQYdtark",
+    "last_login": null,
+    "email": "jodilowery@williams.com",
+    "first_name": "Sarah",
+    "last_name": "Morgan",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.109Z",
+    "updated": "2019-01-24T17:00:21.109Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "2cface48-0692-4ed6-9948-3de353dea7a1",
+  "fields": {
+    "password": "McCFrRUqGOWKndBLRNEH",
+    "last_login": null,
+    "email": "sgomez@gmail.com",
+    "first_name": "Mary",
+    "last_name": "Costa",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.835Z",
+    "updated": "2019-01-24T17:00:20.835Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "30fb16c2-58e0-4c1c-8d7e-f75b2ac0a0d4",
+  "fields": {
+    "password": "BrDfWCGfWFLmqvlfrtcj",
+    "last_login": null,
+    "email": "afriedman@yahoo.com",
+    "first_name": "William",
+    "last_name": "Richardson",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.036Z",
+    "updated": "2019-01-24T17:00:20.036Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "31627a80-4fcd-445a-957a-35649bf3f9c9",
+  "fields": {
+    "password": "jrEjiMxPyafZHKQlXyLa",
+    "last_login": null,
+    "email": "kathryn97@jones-collins.com",
+    "first_name": "Jeremy",
+    "last_name": "Lynch",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.485Z",
+    "updated": "2019-01-24T17:00:21.485Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "322baa71-89dc-414f-a03a-fb45a32a87b8",
+  "fields": {
+    "password": "sdLOsQPetsExfqBvPEkT",
+    "last_login": null,
+    "email": "nchapman@gmail.com",
+    "first_name": "John",
+    "last_name": "Turner",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.914Z",
+    "updated": "2019-01-24T17:00:19.914Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "3246d967-415d-408e-8767-730061a4ea9d",
+  "fields": {
+    "password": "cdTOegpXjyBzZNyUMjQN",
+    "last_login": null,
+    "email": "samanthaerickson@hotmail.com",
+    "first_name": "Anthony",
+    "last_name": "Adams",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.424Z",
+    "updated": "2019-01-24T17:00:20.424Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "391b3570-e10d-4ff9-86b3-906db57b3db5",
+  "fields": {
+    "password": "oqpIFzcYjDkUdrBXtTAj",
+    "last_login": null,
+    "email": "zgould@clark-stone.com",
+    "first_name": "Christopher",
+    "last_name": "Moore",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.112Z",
+    "updated": "2019-01-24T17:00:20.112Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "3e660cbd-a9ba-4e46-b3e6-7d1a9e89b62f",
+  "fields": {
+    "password": "lRZKlRjZNDLxfgMiIqHh",
+    "last_login": null,
+    "email": "heidiweiss@gray-harper.com",
+    "first_name": "Glenda",
+    "last_name": "Morgan",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.173Z",
+    "updated": "2019-01-24T17:00:21.173Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "3f00d479-526a-4c48-bfae-8d30387c3486",
+  "fields": {
+    "password": "esusiRrjejCbZoixhBhB",
+    "last_login": null,
+    "email": "uromero@miller.com",
+    "first_name": "Shawn",
+    "last_name": "Matthews",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.423Z",
+    "updated": "2019-01-24T17:00:21.423Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "407f39a8-2349-4a06-bfbb-e6898479c14e",
+  "fields": {
+    "password": "TivgBCJhSavBXexDXlxb",
+    "last_login": null,
+    "email": "thill@martin.info",
+    "first_name": "Kevin",
+    "last_name": "Bernard",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.646Z",
+    "updated": "2019-01-24T17:00:20.646Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "4cd32212-b689-424d-a4e1-15f820f41699",
+  "fields": {
+    "password": "NgcBNxzmnBMEvdtHAlSD",
+    "last_login": null,
+    "email": "elizabeth62@armstrong-oliver.net",
+    "first_name": "Miguel",
+    "last_name": "Dean",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.544Z",
+    "updated": "2019-01-24T17:00:21.544Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "57a3de9d-1ea2-45ae-ab65-6e1b895781c0",
+  "fields": {
+    "password": "qdUVQLvxjAMGNByAvtee",
+    "last_login": null,
+    "email": "velasquezangela@ortiz.info",
+    "first_name": "Alan",
+    "last_name": "Kim",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.618Z",
+    "updated": "2019-01-24T17:00:19.618Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "57c259d9-2e10-4de9-9ed0-7a21071c467d",
+  "fields": {
+    "password": "xEgzLpCAwCqQiaNsGcUy",
+    "last_login": null,
+    "email": "fmckinney@bauer.biz",
+    "first_name": "Kimberly",
+    "last_name": "Jones",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.424Z",
+    "updated": "2019-01-24T17:00:19.424Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "5d0d9479-d451-45f6-82d6-3cd8759b3fe4",
+  "fields": {
+    "password": "BnYZxMwDTGUoFPqXodGL",
+    "last_login": null,
+    "email": "davidwright@hotmail.com",
+    "first_name": "Kevin",
+    "last_name": "Brown",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.899Z",
+    "updated": "2019-01-24T17:00:20.899Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "62707eb9-4fa5-481f-b554-58ecabb8e4db",
+  "fields": {
+    "password": "AidyRQyDpPdZIkdvNaqu",
+    "last_login": null,
+    "email": "wholmes@yahoo.com",
+    "first_name": "Carolyn",
+    "last_name": "Harrington",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.967Z",
+    "updated": "2019-01-24T17:00:20.967Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "682ef4bf-65bd-4920-8a20-8b1262c3f4d5",
+  "fields": {
+    "password": "NDaJMAqFbInVwZfmNMEe",
+    "last_login": null,
+    "email": "martinezmary@yahoo.com",
+    "first_name": "Ryan",
+    "last_name": "Murray",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.792Z",
+    "updated": "2019-01-24T17:00:19.792Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "814ad95c-886b-4d0d-b6eb-c34f47d22dd7",
+  "fields": {
+    "password": "ohoKIZICrbhAkozwlOlN",
+    "last_login": null,
+    "email": "brandolph@kent.com",
+    "first_name": "Daniel",
+    "last_name": "Hopkins",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.770Z",
+    "updated": "2019-01-24T17:00:20.770Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "81bd24c0-551c-408b-8a78-af2e1f4d0eca",
+  "fields": {
+    "password": "ZDgpHAQSfHCopxzElcmZ",
+    "last_login": null,
+    "email": "jeff87@gomez.com",
+    "first_name": "Chelsea",
+    "last_name": "Turner",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.749Z",
+    "updated": "2019-01-24T17:00:21.749Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "81e1eef3-c5af-447e-9313-03cd84a2fc34",
+  "fields": {
+    "password": "uiFRurVBEgCyetBppEAY",
+    "last_login": null,
+    "email": "umoore@moore.com",
+    "first_name": "Howard",
+    "last_name": "Farmer",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.044Z",
+    "updated": "2019-01-24T17:00:21.044Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "845c0548-f812-4030-be3e-aff469764976",
+  "fields": {
+    "password": "ZFxxCjOBNDMheDKlfBvg",
+    "last_login": null,
+    "email": "luis60@stephenson.com",
+    "first_name": "Christina",
+    "last_name": "Pham",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.490Z",
+    "updated": "2019-01-24T17:00:19.490Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "84cfd42a-6f8c-48a5-a78a-833fc48e10a9",
+  "fields": {
+    "password": "EzNoxhzUQywApMOWtsyE",
+    "last_login": null,
+    "email": "crystal12@martinez.com",
+    "first_name": "Samuel",
+    "last_name": "Delgado",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.691Z",
+    "updated": "2019-01-24T17:00:21.691Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "8d346fb9-1401-4056-8865-ff92d221a6fb",
+  "fields": {
+    "password": "xtMIxiEMUfzEcguGVAAd",
+    "last_login": null,
+    "email": "thomasarcher@walter.com",
+    "first_name": "Michael",
+    "last_name": "Chung",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.967Z",
+    "updated": "2019-01-24T17:00:19.967Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "8f256228-7ebe-48af-8fe8-7db3e8ae145b",
+  "fields": {
+    "password": "xCbEsWfjeSqBhMUMZtHR",
+    "last_login": null,
+    "email": "john74@gutierrez.com",
+    "first_name": "Joseph",
+    "last_name": "Lewis",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.300Z",
+    "updated": "2019-01-24T17:00:21.300Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "912e82b1-8903-4ef6-81dd-a2b81c8e9183",
+  "fields": {
+    "password": "wLsoNzLknZBzqoXuVbys",
+    "last_login": null,
+    "email": "drowe@hotmail.com",
+    "first_name": "Alyssa",
+    "last_name": "Chapman",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.562Z",
+    "updated": "2019-01-24T17:00:20.562Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "912fb078-aa37-4016-b9ee-23a3b93b0182",
+  "fields": {
+    "password": "ftXlUSojSDnuWPGJhgVS",
+    "last_login": null,
+    "email": "william43@hotmail.com",
+    "first_name": "Mark",
+    "last_name": "Carpenter",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.705Z",
+    "updated": "2019-01-24T17:00:20.705Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "91454ef0-361c-48d7-8c2c-44e1b9214b37",
+  "fields": {
+    "password": "PPrZiEfrKPbRyTHpkphk",
+    "last_login": null,
+    "email": "robersonhannah@gmail.com",
+    "first_name": "Christina",
+    "last_name": "Oconnell",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.620Z",
+    "updated": "2019-01-24T17:00:21.620Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "a7689be9-68c4-4cd3-bf21-2fb62053a44d",
+  "fields": {
+    "password": "GMvdDUOvdONspwNJFgXG",
+    "last_login": null,
+    "email": "powelldenise@lewis.com",
+    "first_name": "Karina",
+    "last_name": "Jones",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.555Z",
+    "updated": "2019-01-24T17:00:19.555Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "b2c71b21-2233-4706-9724-8e6989643f55",
+  "fields": {
+    "password": "UPjpWFEKLFYANMKVDKko",
+    "last_login": null,
+    "email": "kristinflores@miranda-miles.com",
+    "first_name": "Frank",
+    "last_name": "Turner",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.339Z",
+    "updated": "2019-01-24T17:00:20.339Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "bd2fa856-d29c-4e09-9ab8-a83c53b18e21",
+  "fields": {
+    "password": "QiTWEBXTlrGiKiogWdVP",
+    "last_login": null,
+    "email": "stephanieharmon@yahoo.com",
+    "first_name": "Carrie",
+    "last_name": "Gonzalez",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.844Z",
+    "updated": "2019-01-24T17:00:19.844Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "bda692b1-1148-4f5a-aa6f-cfd66121f4f1",
+  "fields": {
+    "password": "kXKWEigsiXEDhVZmimGm",
+    "last_login": null,
+    "email": "conleydeborah@perry.biz",
+    "first_name": "Kimberly",
+    "last_name": "Moore",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.673Z",
+    "updated": "2019-01-24T17:00:19.673Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "c1f68e43-3680-4f2a-a21d-c0897a75862b",
+  "fields": {
+    "password": "coTLMzSQLMuqwxpXhLvW",
+    "last_login": null,
+    "email": "imclaughlin@gmail.com",
+    "first_name": "Denise",
+    "last_name": "Campbell",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.503Z",
+    "updated": "2019-01-24T17:00:20.503Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "c91b5c44-07ed-4378-b6d1-57f6215300eb",
+  "fields": {
+    "password": "eFoQfLttEZpxNOSOQSan",
+    "last_login": null,
+    "email": "sharonjohnson@gmail.com",
+    "first_name": "Jason",
+    "last_name": "Andrade",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.241Z",
+    "updated": "2019-01-24T17:00:21.241Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "d2551fc6-05ef-424b-b5b2-9c37a1726342",
+  "fields": {
+    "password": "HkDxxLJUleqYRGWhNtxe",
+    "last_login": null,
+    "email": "raymond71@gmail.com",
+    "first_name": "Jason",
+    "last_name": "Williams",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.369Z",
+    "updated": "2019-01-24T17:00:21.369Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "e1a0e808-eb60-4052-b5cf-1900011de35f",
+  "fields": {
+    "password": "PEEyylsKIpEIPZTAHkIF",
+    "last_login": null,
+    "email": "ruthnolan@mitchell-sims.com",
+    "first_name": "Michelle",
+    "last_name": "Savage",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:19.724Z",
+    "updated": "2019-01-24T17:00:19.724Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "e5a22d40-faf8-47d4-9dfe-a557a1bec9c3",
+  "fields": {
+    "password": "ZyeXWWQypLUswupZLsfR",
+    "last_login": null,
+    "email": "markjohnson@yahoo.com",
+    "first_name": "Candice",
+    "last_name": "Craig",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:20.194Z",
+    "updated": "2019-01-24T17:00:20.194Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "pk": "fa4a6c3d-fa6a-4633-8045-35f47d6f1a0b",
+  "fields": {
+    "password": "UsVDHmUVQpnehEdOvQLg",
+    "last_login": null,
+    "email": "sheryl57@rivera.com",
+    "first_name": "Jared",
+    "last_name": "Mendoza",
+    "date_of_birth": null,
+    "date_joined": "2019-01-24T17:00:21.819Z",
+    "updated": "2019-01-24T17:00:21.819Z",
+    "is_active": true,
+    "is_staff": false,
+    "is_superuser": false,
+    "is_employer": false,
+    "is_seeker": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 1,
+  "fields": {
+    "user": "57c259d9-2e10-4de9-9ed0-7a21071c467d",
+    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+    "salary_min": 0,
+    "salary_max": 80000,
+    "experience": 26,
+    "about": "Threat eight culture front safe same reason understand. Agreement night minute notice.\nBehind political edge one matter bed serve over. Democratic service baby light family office member.",
+    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+    "created": "2019-01-24T17:00:19.452Z",
+    "updated": "2019-01-24T17:00:19.452Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 2,
+  "fields": {
+    "user": "845c0548-f812-4030-be3e-aff469764976",
+    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 30000,
+    "salary_max": 0,
+    "experience": 8,
+    "about": "Its increase form town along machine environmental. Job lose less fall deal. Together against pick forward outside simple modern.",
+    "city": "\u041f\u0435\u0440\u043c\u044c",
+    "created": "2019-01-24T17:00:19.520Z",
+    "updated": "2019-01-24T17:00:19.520Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 3,
+  "fields": {
+    "user": "a7689be9-68c4-4cd3-bf21-2fb62053a44d",
+    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 30000,
+    "salary_max": 60000,
+    "experience": 1,
+    "about": "Indeed according mean particular second after. Else lose create born part. Force situation us.",
+    "city": "\u0412\u043e\u0440\u043e\u043d\u0435\u0436",
+    "created": "2019-01-24T17:00:19.594Z",
+    "updated": "2019-01-24T17:00:19.594Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 4,
+  "fields": {
+    "user": "57a3de9d-1ea2-45ae-ab65-6e1b895781c0",
+    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+    "salary_min": 40000,
+    "salary_max": 60000,
+    "experience": 21,
+    "about": "Respond someone last first leg. Down strategy often land reach type. Process long check middle. Various commercial speech night.",
+    "city": "\u041e\u043c\u0441\u043a",
+    "created": "2019-01-24T17:00:19.644Z",
+    "updated": "2019-01-24T17:00:19.644Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 5,
+  "fields": {
+    "user": "bda692b1-1148-4f5a-aa6f-cfd66121f4f1",
+    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+    "salary_min": 40000,
+    "salary_max": 60000,
+    "experience": 15,
+    "about": "Event sport but play certain now option. East whether this activity couple. Sea better offer woman simply person.",
+    "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
+    "created": "2019-01-24T17:00:19.698Z",
+    "updated": "2019-01-24T17:00:19.698Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 6,
+  "fields": {
+    "user": "e1a0e808-eb60-4052-b5cf-1900011de35f",
+    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 0,
+    "salary_max": 80000,
+    "experience": 23,
+    "about": "Politics recent team doctor type able only. Physical cultural long major. Direction show administration including.",
+    "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
+    "created": "2019-01-24T17:00:19.755Z",
+    "updated": "2019-01-24T17:00:19.756Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 7,
+  "fields": {
+    "user": "682ef4bf-65bd-4920-8a20-8b1262c3f4d5",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 50000,
+    "salary_max": 80000,
+    "experience": 12,
+    "about": "Sometimes remain three. Cell single white case nature.\nTree phone idea really. Meeting piece alone provide while scene. Need total season travel tend reason.",
+    "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
+    "created": "2019-01-24T17:00:19.818Z",
+    "updated": "2019-01-24T17:00:19.818Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 8,
+  "fields": {
+    "user": "bd2fa856-d29c-4e09-9ab8-a83c53b18e21",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 40000,
+    "salary_max": 0,
+    "experience": 5,
+    "about": "Still seat street room reason trade. Allow affect we. Eye car part image ability.\nBar my first land price. Cultural off reason happen all. Myself really half hold choice hard a.",
+    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+    "created": "2019-01-24T17:00:19.886Z",
+    "updated": "2019-01-24T17:00:19.886Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 9,
+  "fields": {
+    "user": "322baa71-89dc-414f-a03a-fb45a32a87b8",
+    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 0,
+    "salary_max": 80000,
+    "experience": 7,
+    "about": "Stage which two three enjoy change build. Center blue blood buy.\nOrganization soon after value. Question give myself car when civil.",
+    "city": "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a",
+    "created": "2019-01-24T17:00:19.941Z",
+    "updated": "2019-01-24T17:00:19.941Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 10,
+  "fields": {
+    "user": "8d346fb9-1401-4056-8865-ff92d221a6fb",
+    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 40000,
+    "salary_max": 100000,
+    "experience": 9,
+    "about": "Hold only exist and skill same pull. Phone teacher southern right type. So size put exist. Cause pass herself when kind.\nPlace newspaper people popular. Woman between Republican care.",
+    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+    "created": "2019-01-24T17:00:19.993Z",
+    "updated": "2019-01-24T17:00:19.993Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 11,
+  "fields": {
+    "user": "30fb16c2-58e0-4c1c-8d7e-f75b2ac0a0d4",
+    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+    "salary_min": 0,
+    "salary_max": 0,
+    "experience": 24,
+    "about": "West official fish realize down area might argue. Avoid others yeah bad understand.\nLearn machine report upon wish eat. These growth safe return wide strategy produce.",
+    "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
+    "created": "2019-01-24T17:00:20.068Z",
+    "updated": "2019-01-24T17:00:20.068Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 12,
+  "fields": {
+    "user": "391b3570-e10d-4ff9-86b3-906db57b3db5",
+    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 40000,
+    "salary_max": 0,
+    "experience": 18,
+    "about": "Force social house institution although decision. Assume nor feel same prevent behavior. Society move suffer a gas let company.",
+    "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
+    "created": "2019-01-24T17:00:20.156Z",
+    "updated": "2019-01-24T17:00:20.156Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 13,
+  "fields": {
+    "user": "e5a22d40-faf8-47d4-9dfe-a557a1bec9c3",
+    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+    "salary_min": 30000,
+    "salary_max": 60000,
+    "experience": 8,
+    "about": "Outside whom significant figure. Science charge fish they sign school get. Eye return get skill face pass.",
+    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+    "created": "2019-01-24T17:00:20.234Z",
+    "updated": "2019-01-24T17:00:20.234Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 14,
+  "fields": {
+    "user": "22242431-d4c7-452c-8340-be143ca10563",
+    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+    "salary_min": 0,
+    "salary_max": 80000,
+    "experience": 33,
+    "about": "Smile allow must available consumer individual see. While no house sure issue feeling room. Very more direction financial assume seem red way.\nDeal run issue. Door often pull.",
+    "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
+    "created": "2019-01-24T17:00:20.308Z",
+    "updated": "2019-01-24T17:00:20.308Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 15,
+  "fields": {
+    "user": "b2c71b21-2233-4706-9724-8e6989643f55",
+    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+    "salary_min": 0,
+    "salary_max": 0,
+    "experience": 32,
+    "about": "Least able mean skin everyone successful. Until mouth chair apply there big.\nCharge hard relationship hour thousand painting admit. Small leave on meet. Upon manager within account figure support.",
+    "city": "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a",
+    "created": "2019-01-24T17:00:20.368Z",
+    "updated": "2019-01-24T17:00:20.368Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 16,
+  "fields": {
+    "user": "3246d967-415d-408e-8767-730061a4ea9d",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 0,
+    "salary_max": 80000,
+    "experience": 33,
+    "about": "Thus little quality choice which into kind political. South daughter smile Congress. Those station wife.",
+    "city": "\u041a\u0430\u0437\u0430\u043d\u044c",
+    "created": "2019-01-24T17:00:20.465Z",
+    "updated": "2019-01-24T17:00:20.465Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 17,
+  "fields": {
+    "user": "c1f68e43-3680-4f2a-a21d-c0897a75862b",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 40000,
+    "salary_max": 100000,
+    "experience": 35,
+    "about": "Power system positive herself story rather. Program owner think decade also individual eight. Until candidate middle perform. Floor court rest skill nature easy.",
+    "city": "\u041f\u0435\u0440\u043c\u044c",
+    "created": "2019-01-24T17:00:20.530Z",
+    "updated": "2019-01-24T17:00:20.530Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 18,
+  "fields": {
+    "user": "912e82b1-8903-4ef6-81dd-a2b81c8e9183",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 30000,
+    "salary_max": 60000,
+    "experience": 5,
+    "about": "Opportunity create participant so. Choose turn maintain consider bill miss prevent. National charge small decision list sure level economic.",
+    "city": "\u0421\u0430\u043c\u0430\u0440\u0430",
+    "created": "2019-01-24T17:00:20.614Z",
+    "updated": "2019-01-24T17:00:20.614Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 19,
+  "fields": {
+    "user": "407f39a8-2349-4a06-bfbb-e6898479c14e",
+    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+    "salary_min": 0,
+    "salary_max": 100000,
+    "experience": 12,
+    "about": "Very something perhaps season school shoulder no. Account detail us.\nRecently try space hold rest. Say plant main unit just be. Deal whether relate skill program management after.",
+    "city": "\u041d\u0438\u0436\u043d\u0438\u0439 \u041d\u043e\u0432\u0433\u043e\u0440\u043e\u0434",
+    "created": "2019-01-24T17:00:20.682Z",
+    "updated": "2019-01-24T17:00:20.682Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 20,
+  "fields": {
+    "user": "912fb078-aa37-4016-b9ee-23a3b93b0182",
+    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 50000,
+    "salary_max": 60000,
+    "experience": 18,
+    "about": "Up ten moment between personal alone economy. Particularly also detail trip training throw. Buy kind technology try trip. Large through establish natural.",
+    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+    "created": "2019-01-24T17:00:20.731Z",
+    "updated": "2019-01-24T17:00:20.731Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 21,
+  "fields": {
+    "user": "814ad95c-886b-4d0d-b6eb-c34f47d22dd7",
+    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 40000,
+    "salary_max": 0,
+    "experience": 9,
+    "about": "Describe out from play situation sure agreement they. People city short policy section director. Realize administration there remain.",
+    "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
+    "created": "2019-01-24T17:00:20.807Z",
+    "updated": "2019-01-24T17:00:20.807Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 22,
+  "fields": {
+    "user": "2cface48-0692-4ed6-9948-3de353dea7a1",
+    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 0,
+    "salary_max": 80000,
+    "experience": 32,
+    "about": "Hope quickly happen box own meeting. Learn art relationship know school.\nOpen why surface hold different indicate moment. Year song thank work much.",
+    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+    "created": "2019-01-24T17:00:20.867Z",
+    "updated": "2019-01-24T17:00:20.867Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 23,
+  "fields": {
+    "user": "5d0d9479-d451-45f6-82d6-3cd8759b3fe4",
+    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 50000,
+    "salary_max": 0,
+    "experience": 9,
+    "about": "See yes material during physical our federal deal. And focus loss green. Spend police mother large.\nInside lot floor. Your line back share.",
+    "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
+    "created": "2019-01-24T17:00:20.925Z",
+    "updated": "2019-01-24T17:00:20.925Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 24,
+  "fields": {
+    "user": "62707eb9-4fa5-481f-b554-58ecabb8e4db",
+    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 30000,
+    "salary_max": 80000,
+    "experience": 15,
+    "about": "Member defense part our of rate should. Example high reason occur machine forward edge main. Single name day truth interesting. According one choose long life.",
+    "city": "\u041f\u0435\u0440\u043c\u044c",
+    "created": "2019-01-24T17:00:20.997Z",
+    "updated": "2019-01-24T17:00:20.997Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 25,
+  "fields": {
+    "user": "81e1eef3-c5af-447e-9313-03cd84a2fc34",
+    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 40000,
+    "salary_max": 100000,
+    "experience": 13,
+    "about": "Letter table that heart. Member pay or shake baby.\nParticipant often effort director source about. Exactly its red player performance. Each the play animal coach your.",
+    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+    "created": "2019-01-24T17:00:21.069Z",
+    "updated": "2019-01-24T17:00:21.069Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 26,
+  "fields": {
+    "user": "25db6356-51c9-470f-904c-eaedd8b8b6c3",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 0,
+    "salary_max": 0,
+    "experience": 30,
+    "about": "Turn person some any forward already represent figure. Imagine entire appear term support despite apply.",
+    "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
+    "created": "2019-01-24T17:00:21.148Z",
+    "updated": "2019-01-24T17:00:21.148Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 27,
+  "fields": {
+    "user": "3e660cbd-a9ba-4e46-b3e6-7d1a9e89b62f",
+    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 30000,
+    "salary_max": 100000,
+    "experience": 23,
+    "about": "Foreign before then when eye. Describe former official history court task actually.\nHope with fire action. Force spring white minute section energy visit point.",
+    "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
+    "created": "2019-01-24T17:00:21.203Z",
+    "updated": "2019-01-24T17:00:21.203Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 28,
+  "fields": {
+    "user": "c91b5c44-07ed-4378-b6d1-57f6215300eb",
+    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 50000,
+    "salary_max": 60000,
+    "experience": 4,
+    "about": "People there station sea idea. Tree never light standard. Easy form join among yard explain.",
+    "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
+    "created": "2019-01-24T17:00:21.272Z",
+    "updated": "2019-01-24T17:00:21.272Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 29,
+  "fields": {
+    "user": "8f256228-7ebe-48af-8fe8-7db3e8ae145b",
+    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 0,
+    "salary_max": 80000,
+    "experience": 0,
+    "about": "What sister describe already majority behavior. Meeting fish talk improve. Remain power ability media think.",
+    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+    "created": "2019-01-24T17:00:21.326Z",
+    "updated": "2019-01-24T17:00:21.326Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 30,
+  "fields": {
+    "user": "d2551fc6-05ef-424b-b5b2-9c37a1726342",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 30000,
+    "salary_max": 0,
+    "experience": 5,
+    "about": "Change teach owner book. Early street hard also. Spend experience main purpose thank try certainly risk.\nWe senior summer standard put. Upon western wrong really card appear interesting.",
+    "city": "\u0423\u0444\u0430",
+    "created": "2019-01-24T17:00:21.392Z",
+    "updated": "2019-01-24T17:00:21.392Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 31,
+  "fields": {
+    "user": "3f00d479-526a-4c48-bfae-8d30387c3486",
+    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+    "salary_min": 40000,
+    "salary_max": 100000,
+    "experience": 14,
+    "about": "Month measure where what my stop. Design face officer team.\nUnderstand near at team occur him. Avoid yard image black. Law nature only make pull hit.",
+    "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
+    "created": "2019-01-24T17:00:21.447Z",
+    "updated": "2019-01-24T17:00:21.447Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 32,
+  "fields": {
+    "user": "31627a80-4fcd-445a-957a-35649bf3f9c9",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 40000,
+    "salary_max": 80000,
+    "experience": 3,
+    "about": "Beat main country very story they teacher. Chair because voice can respond. Decade customer experience whatever test could song.",
+    "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
+    "created": "2019-01-24T17:00:21.508Z",
+    "updated": "2019-01-24T17:00:21.508Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 33,
+  "fields": {
+    "user": "4cd32212-b689-424d-a4e1-15f820f41699",
+    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+    "salary_min": 50000,
+    "salary_max": 80000,
+    "experience": 30,
+    "about": "Scene next management point big. Material store number education house.\nBefore reduce save. Then total television each put.",
+    "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
+    "created": "2019-01-24T17:00:21.583Z",
+    "updated": "2019-01-24T17:00:21.583Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 34,
+  "fields": {
+    "user": "91454ef0-361c-48d7-8c2c-44e1b9214b37",
+    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 50000,
+    "salary_max": 100000,
+    "experience": 9,
+    "about": "Special during record pressure raise edge. Fly according read upon discussion recently herself.",
+    "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
+    "created": "2019-01-24T17:00:21.658Z",
+    "updated": "2019-01-24T17:00:21.658Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 35,
+  "fields": {
+    "user": "84cfd42a-6f8c-48a5-a78a-833fc48e10a9",
+    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+    "salary_min": 50000,
+    "salary_max": 80000,
+    "experience": 0,
+    "about": "Plan history tax fear into church character. Series often reveal less paper.\nInterview somebody thing call partner price others. Standard improve within artist information program small.",
+    "city": "\u0412\u043e\u0440\u043e\u043d\u0435\u0436",
+    "created": "2019-01-24T17:00:21.719Z",
+    "updated": "2019-01-24T17:00:21.719Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 36,
+  "fields": {
+    "user": "81bd24c0-551c-408b-8a78-af2e1f4d0eca",
+    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+    "salary_min": 40000,
+    "salary_max": 80000,
+    "experience": 23,
+    "about": "Minute sense fire always be including. Argue record chair popular. Mother since bag decade talk black last.",
+    "city": "\u041a\u0430\u0437\u0430\u043d\u044c",
+    "created": "2019-01-24T17:00:21.782Z",
+    "updated": "2019-01-24T17:00:21.782Z"
+  }
+},
+{
+  "model": "resumes.resume",
+  "pk": 37,
+  "fields": {
+    "user": "fa4a6c3d-fa6a-4633-8045-35f47d6f1a0b",
+    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+    "salary_min": 50000,
+    "salary_max": 100000,
+    "experience": 35,
+    "about": "Message myself form doctor. Beautiful hair paper reality through have attorney big. Cost until another.\nFew available imagine wish least. By skill teacher total. Create street message rather inside.",
+    "city": "\u041f\u0435\u0440\u043c\u044c",
+    "created": "2019-01-24T17:00:21.851Z",
+    "updated": "2019-01-24T17:00:21.851Z"
+  }
+}
+]

--- a/users_resume_dump.json
+++ b/users_resume_dump.json
@@ -1,1334 +1,1333 @@
-[
-{
-  "model": "users.user",
-  "pk": "22242431-d4c7-452c-8340-be143ca10563",
-  "fields": {
-    "password": "suXHDYosGScSAxdLIDCJ",
-    "last_login": null,
-    "email": "pearsonkatie@yahoo.com",
-    "first_name": "Mary",
-    "last_name": "Todd",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.277Z",
-    "updated": "2019-01-24T17:00:20.277Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
+[{
+    "model": "users.user",
+    "pk": "22242431-d4c7-452c-8340-be143ca10563",
+    "fields": {
+      "password": "suXHDYosGScSAxdLIDCJ",
+      "last_login": null,
+      "email": "pearsonkatie@yahoo.com",
+      "first_name": "Mary",
+      "last_name": "Todd",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.277Z",
+      "updated": "2019-01-24T17:00:20.277Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "25db6356-51c9-470f-904c-eaedd8b8b6c3",
+    "fields": {
+      "password": "qVmiXQNghsaoBQYdtark",
+      "last_login": null,
+      "email": "jodilowery@williams.com",
+      "first_name": "Sarah",
+      "last_name": "Morgan",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.109Z",
+      "updated": "2019-01-24T17:00:21.109Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "2cface48-0692-4ed6-9948-3de353dea7a1",
+    "fields": {
+      "password": "McCFrRUqGOWKndBLRNEH",
+      "last_login": null,
+      "email": "sgomez@gmail.com",
+      "first_name": "Mary",
+      "last_name": "Costa",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.835Z",
+      "updated": "2019-01-24T17:00:20.835Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "30fb16c2-58e0-4c1c-8d7e-f75b2ac0a0d4",
+    "fields": {
+      "password": "BrDfWCGfWFLmqvlfrtcj",
+      "last_login": null,
+      "email": "afriedman@yahoo.com",
+      "first_name": "William",
+      "last_name": "Richardson",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.036Z",
+      "updated": "2019-01-24T17:00:20.036Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "31627a80-4fcd-445a-957a-35649bf3f9c9",
+    "fields": {
+      "password": "jrEjiMxPyafZHKQlXyLa",
+      "last_login": null,
+      "email": "kathryn97@jones-collins.com",
+      "first_name": "Jeremy",
+      "last_name": "Lynch",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.485Z",
+      "updated": "2019-01-24T17:00:21.485Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "322baa71-89dc-414f-a03a-fb45a32a87b8",
+    "fields": {
+      "password": "sdLOsQPetsExfqBvPEkT",
+      "last_login": null,
+      "email": "nchapman@gmail.com",
+      "first_name": "John",
+      "last_name": "Turner",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.914Z",
+      "updated": "2019-01-24T17:00:19.914Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "3246d967-415d-408e-8767-730061a4ea9d",
+    "fields": {
+      "password": "cdTOegpXjyBzZNyUMjQN",
+      "last_login": null,
+      "email": "samanthaerickson@hotmail.com",
+      "first_name": "Anthony",
+      "last_name": "Adams",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.424Z",
+      "updated": "2019-01-24T17:00:20.424Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "391b3570-e10d-4ff9-86b3-906db57b3db5",
+    "fields": {
+      "password": "oqpIFzcYjDkUdrBXtTAj",
+      "last_login": null,
+      "email": "zgould@clark-stone.com",
+      "first_name": "Christopher",
+      "last_name": "Moore",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.112Z",
+      "updated": "2019-01-24T17:00:20.112Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "3e660cbd-a9ba-4e46-b3e6-7d1a9e89b62f",
+    "fields": {
+      "password": "lRZKlRjZNDLxfgMiIqHh",
+      "last_login": null,
+      "email": "heidiweiss@gray-harper.com",
+      "first_name": "Glenda",
+      "last_name": "Morgan",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.173Z",
+      "updated": "2019-01-24T17:00:21.173Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "3f00d479-526a-4c48-bfae-8d30387c3486",
+    "fields": {
+      "password": "esusiRrjejCbZoixhBhB",
+      "last_login": null,
+      "email": "uromero@miller.com",
+      "first_name": "Shawn",
+      "last_name": "Matthews",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.423Z",
+      "updated": "2019-01-24T17:00:21.423Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "407f39a8-2349-4a06-bfbb-e6898479c14e",
+    "fields": {
+      "password": "TivgBCJhSavBXexDXlxb",
+      "last_login": null,
+      "email": "thill@martin.info",
+      "first_name": "Kevin",
+      "last_name": "Bernard",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.646Z",
+      "updated": "2019-01-24T17:00:20.646Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "4cd32212-b689-424d-a4e1-15f820f41699",
+    "fields": {
+      "password": "NgcBNxzmnBMEvdtHAlSD",
+      "last_login": null,
+      "email": "elizabeth62@armstrong-oliver.net",
+      "first_name": "Miguel",
+      "last_name": "Dean",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.544Z",
+      "updated": "2019-01-24T17:00:21.544Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "57a3de9d-1ea2-45ae-ab65-6e1b895781c0",
+    "fields": {
+      "password": "qdUVQLvxjAMGNByAvtee",
+      "last_login": null,
+      "email": "velasquezangela@ortiz.info",
+      "first_name": "Alan",
+      "last_name": "Kim",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.618Z",
+      "updated": "2019-01-24T17:00:19.618Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "57c259d9-2e10-4de9-9ed0-7a21071c467d",
+    "fields": {
+      "password": "xEgzLpCAwCqQiaNsGcUy",
+      "last_login": null,
+      "email": "fmckinney@bauer.biz",
+      "first_name": "Kimberly",
+      "last_name": "Jones",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.424Z",
+      "updated": "2019-01-24T17:00:19.424Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "5d0d9479-d451-45f6-82d6-3cd8759b3fe4",
+    "fields": {
+      "password": "BnYZxMwDTGUoFPqXodGL",
+      "last_login": null,
+      "email": "davidwright@hotmail.com",
+      "first_name": "Kevin",
+      "last_name": "Brown",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.899Z",
+      "updated": "2019-01-24T17:00:20.899Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "62707eb9-4fa5-481f-b554-58ecabb8e4db",
+    "fields": {
+      "password": "AidyRQyDpPdZIkdvNaqu",
+      "last_login": null,
+      "email": "wholmes@yahoo.com",
+      "first_name": "Carolyn",
+      "last_name": "Harrington",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.967Z",
+      "updated": "2019-01-24T17:00:20.967Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "682ef4bf-65bd-4920-8a20-8b1262c3f4d5",
+    "fields": {
+      "password": "NDaJMAqFbInVwZfmNMEe",
+      "last_login": null,
+      "email": "martinezmary@yahoo.com",
+      "first_name": "Ryan",
+      "last_name": "Murray",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.792Z",
+      "updated": "2019-01-24T17:00:19.792Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "814ad95c-886b-4d0d-b6eb-c34f47d22dd7",
+    "fields": {
+      "password": "ohoKIZICrbhAkozwlOlN",
+      "last_login": null,
+      "email": "brandolph@kent.com",
+      "first_name": "Daniel",
+      "last_name": "Hopkins",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.770Z",
+      "updated": "2019-01-24T17:00:20.770Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "81bd24c0-551c-408b-8a78-af2e1f4d0eca",
+    "fields": {
+      "password": "ZDgpHAQSfHCopxzElcmZ",
+      "last_login": null,
+      "email": "jeff87@gomez.com",
+      "first_name": "Chelsea",
+      "last_name": "Turner",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.749Z",
+      "updated": "2019-01-24T17:00:21.749Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "81e1eef3-c5af-447e-9313-03cd84a2fc34",
+    "fields": {
+      "password": "uiFRurVBEgCyetBppEAY",
+      "last_login": null,
+      "email": "umoore@moore.com",
+      "first_name": "Howard",
+      "last_name": "Farmer",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.044Z",
+      "updated": "2019-01-24T17:00:21.044Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "845c0548-f812-4030-be3e-aff469764976",
+    "fields": {
+      "password": "ZFxxCjOBNDMheDKlfBvg",
+      "last_login": null,
+      "email": "luis60@stephenson.com",
+      "first_name": "Christina",
+      "last_name": "Pham",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.490Z",
+      "updated": "2019-01-24T17:00:19.490Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "84cfd42a-6f8c-48a5-a78a-833fc48e10a9",
+    "fields": {
+      "password": "EzNoxhzUQywApMOWtsyE",
+      "last_login": null,
+      "email": "crystal12@martinez.com",
+      "first_name": "Samuel",
+      "last_name": "Delgado",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.691Z",
+      "updated": "2019-01-24T17:00:21.691Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "8d346fb9-1401-4056-8865-ff92d221a6fb",
+    "fields": {
+      "password": "xtMIxiEMUfzEcguGVAAd",
+      "last_login": null,
+      "email": "thomasarcher@walter.com",
+      "first_name": "Michael",
+      "last_name": "Chung",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.967Z",
+      "updated": "2019-01-24T17:00:19.967Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "8f256228-7ebe-48af-8fe8-7db3e8ae145b",
+    "fields": {
+      "password": "xCbEsWfjeSqBhMUMZtHR",
+      "last_login": null,
+      "email": "john74@gutierrez.com",
+      "first_name": "Joseph",
+      "last_name": "Lewis",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.300Z",
+      "updated": "2019-01-24T17:00:21.300Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "912e82b1-8903-4ef6-81dd-a2b81c8e9183",
+    "fields": {
+      "password": "wLsoNzLknZBzqoXuVbys",
+      "last_login": null,
+      "email": "drowe@hotmail.com",
+      "first_name": "Alyssa",
+      "last_name": "Chapman",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.562Z",
+      "updated": "2019-01-24T17:00:20.562Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "912fb078-aa37-4016-b9ee-23a3b93b0182",
+    "fields": {
+      "password": "ftXlUSojSDnuWPGJhgVS",
+      "last_login": null,
+      "email": "william43@hotmail.com",
+      "first_name": "Mark",
+      "last_name": "Carpenter",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.705Z",
+      "updated": "2019-01-24T17:00:20.705Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "91454ef0-361c-48d7-8c2c-44e1b9214b37",
+    "fields": {
+      "password": "PPrZiEfrKPbRyTHpkphk",
+      "last_login": null,
+      "email": "robersonhannah@gmail.com",
+      "first_name": "Christina",
+      "last_name": "Oconnell",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.620Z",
+      "updated": "2019-01-24T17:00:21.620Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "a7689be9-68c4-4cd3-bf21-2fb62053a44d",
+    "fields": {
+      "password": "GMvdDUOvdONspwNJFgXG",
+      "last_login": null,
+      "email": "powelldenise@lewis.com",
+      "first_name": "Karina",
+      "last_name": "Jones",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.555Z",
+      "updated": "2019-01-24T17:00:19.555Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "b2c71b21-2233-4706-9724-8e6989643f55",
+    "fields": {
+      "password": "UPjpWFEKLFYANMKVDKko",
+      "last_login": null,
+      "email": "kristinflores@miranda-miles.com",
+      "first_name": "Frank",
+      "last_name": "Turner",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.339Z",
+      "updated": "2019-01-24T17:00:20.339Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "bd2fa856-d29c-4e09-9ab8-a83c53b18e21",
+    "fields": {
+      "password": "QiTWEBXTlrGiKiogWdVP",
+      "last_login": null,
+      "email": "stephanieharmon@yahoo.com",
+      "first_name": "Carrie",
+      "last_name": "Gonzalez",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.844Z",
+      "updated": "2019-01-24T17:00:19.844Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "bda692b1-1148-4f5a-aa6f-cfd66121f4f1",
+    "fields": {
+      "password": "kXKWEigsiXEDhVZmimGm",
+      "last_login": null,
+      "email": "conleydeborah@perry.biz",
+      "first_name": "Kimberly",
+      "last_name": "Moore",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.673Z",
+      "updated": "2019-01-24T17:00:19.673Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "c1f68e43-3680-4f2a-a21d-c0897a75862b",
+    "fields": {
+      "password": "coTLMzSQLMuqwxpXhLvW",
+      "last_login": null,
+      "email": "imclaughlin@gmail.com",
+      "first_name": "Denise",
+      "last_name": "Campbell",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.503Z",
+      "updated": "2019-01-24T17:00:20.503Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "c91b5c44-07ed-4378-b6d1-57f6215300eb",
+    "fields": {
+      "password": "eFoQfLttEZpxNOSOQSan",
+      "last_login": null,
+      "email": "sharonjohnson@gmail.com",
+      "first_name": "Jason",
+      "last_name": "Andrade",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.241Z",
+      "updated": "2019-01-24T17:00:21.241Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "d2551fc6-05ef-424b-b5b2-9c37a1726342",
+    "fields": {
+      "password": "HkDxxLJUleqYRGWhNtxe",
+      "last_login": null,
+      "email": "raymond71@gmail.com",
+      "first_name": "Jason",
+      "last_name": "Williams",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.369Z",
+      "updated": "2019-01-24T17:00:21.369Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "e1a0e808-eb60-4052-b5cf-1900011de35f",
+    "fields": {
+      "password": "PEEyylsKIpEIPZTAHkIF",
+      "last_login": null,
+      "email": "ruthnolan@mitchell-sims.com",
+      "first_name": "Michelle",
+      "last_name": "Savage",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:19.724Z",
+      "updated": "2019-01-24T17:00:19.724Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "e5a22d40-faf8-47d4-9dfe-a557a1bec9c3",
+    "fields": {
+      "password": "ZyeXWWQypLUswupZLsfR",
+      "last_login": null,
+      "email": "markjohnson@yahoo.com",
+      "first_name": "Candice",
+      "last_name": "Craig",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:20.194Z",
+      "updated": "2019-01-24T17:00:20.194Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "users.user",
+    "pk": "fa4a6c3d-fa6a-4633-8045-35f47d6f1a0b",
+    "fields": {
+      "password": "UsVDHmUVQpnehEdOvQLg",
+      "last_login": null,
+      "email": "sheryl57@rivera.com",
+      "first_name": "Jared",
+      "last_name": "Mendoza",
+      "date_of_birth": null,
+      "date_joined": "2019-01-24T17:00:21.819Z",
+      "updated": "2019-01-24T17:00:21.819Z",
+      "is_active": true,
+      "is_staff": false,
+      "is_superuser": false,
+      "is_employer": false,
+
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 1,
+    "fields": {
+      "user": "57c259d9-2e10-4de9-9ed0-7a21071c467d",
+      "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+      "salary_min": 0,
+      "salary_max": 80000,
+      "experience": 26,
+      "about": "Threat eight culture front safe same reason understand. Agreement night minute notice.\nBehind political edge one matter bed serve over. Democratic service baby light family office member.",
+      "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+      "created": "2019-01-24T17:00:19.452Z",
+      "updated": "2019-01-24T17:00:19.452Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 2,
+    "fields": {
+      "user": "845c0548-f812-4030-be3e-aff469764976",
+      "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 30000,
+      "salary_max": 0,
+      "experience": 8,
+      "about": "Its increase form town along machine environmental. Job lose less fall deal. Together against pick forward outside simple modern.",
+      "city": "\u041f\u0435\u0440\u043c\u044c",
+      "created": "2019-01-24T17:00:19.520Z",
+      "updated": "2019-01-24T17:00:19.520Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 3,
+    "fields": {
+      "user": "a7689be9-68c4-4cd3-bf21-2fb62053a44d",
+      "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 30000,
+      "salary_max": 60000,
+      "experience": 1,
+      "about": "Indeed according mean particular second after. Else lose create born part. Force situation us.",
+      "city": "\u0412\u043e\u0440\u043e\u043d\u0435\u0436",
+      "created": "2019-01-24T17:00:19.594Z",
+      "updated": "2019-01-24T17:00:19.594Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 4,
+    "fields": {
+      "user": "57a3de9d-1ea2-45ae-ab65-6e1b895781c0",
+      "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+      "salary_min": 40000,
+      "salary_max": 60000,
+      "experience": 21,
+      "about": "Respond someone last first leg. Down strategy often land reach type. Process long check middle. Various commercial speech night.",
+      "city": "\u041e\u043c\u0441\u043a",
+      "created": "2019-01-24T17:00:19.644Z",
+      "updated": "2019-01-24T17:00:19.644Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 5,
+    "fields": {
+      "user": "bda692b1-1148-4f5a-aa6f-cfd66121f4f1",
+      "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+      "salary_min": 40000,
+      "salary_max": 60000,
+      "experience": 15,
+      "about": "Event sport but play certain now option. East whether this activity couple. Sea better offer woman simply person.",
+      "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
+      "created": "2019-01-24T17:00:19.698Z",
+      "updated": "2019-01-24T17:00:19.698Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 6,
+    "fields": {
+      "user": "e1a0e808-eb60-4052-b5cf-1900011de35f",
+      "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 0,
+      "salary_max": 80000,
+      "experience": 23,
+      "about": "Politics recent team doctor type able only. Physical cultural long major. Direction show administration including.",
+      "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
+      "created": "2019-01-24T17:00:19.755Z",
+      "updated": "2019-01-24T17:00:19.756Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 7,
+    "fields": {
+      "user": "682ef4bf-65bd-4920-8a20-8b1262c3f4d5",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 50000,
+      "salary_max": 80000,
+      "experience": 12,
+      "about": "Sometimes remain three. Cell single white case nature.\nTree phone idea really. Meeting piece alone provide while scene. Need total season travel tend reason.",
+      "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
+      "created": "2019-01-24T17:00:19.818Z",
+      "updated": "2019-01-24T17:00:19.818Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 8,
+    "fields": {
+      "user": "bd2fa856-d29c-4e09-9ab8-a83c53b18e21",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 40000,
+      "salary_max": 0,
+      "experience": 5,
+      "about": "Still seat street room reason trade. Allow affect we. Eye car part image ability.\nBar my first land price. Cultural off reason happen all. Myself really half hold choice hard a.",
+      "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+      "created": "2019-01-24T17:00:19.886Z",
+      "updated": "2019-01-24T17:00:19.886Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 9,
+    "fields": {
+      "user": "322baa71-89dc-414f-a03a-fb45a32a87b8",
+      "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 0,
+      "salary_max": 80000,
+      "experience": 7,
+      "about": "Stage which two three enjoy change build. Center blue blood buy.\nOrganization soon after value. Question give myself car when civil.",
+      "city": "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a",
+      "created": "2019-01-24T17:00:19.941Z",
+      "updated": "2019-01-24T17:00:19.941Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 10,
+    "fields": {
+      "user": "8d346fb9-1401-4056-8865-ff92d221a6fb",
+      "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 40000,
+      "salary_max": 100000,
+      "experience": 9,
+      "about": "Hold only exist and skill same pull. Phone teacher southern right type. So size put exist. Cause pass herself when kind.\nPlace newspaper people popular. Woman between Republican care.",
+      "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+      "created": "2019-01-24T17:00:19.993Z",
+      "updated": "2019-01-24T17:00:19.993Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 11,
+    "fields": {
+      "user": "30fb16c2-58e0-4c1c-8d7e-f75b2ac0a0d4",
+      "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+      "salary_min": 0,
+      "salary_max": 0,
+      "experience": 24,
+      "about": "West official fish realize down area might argue. Avoid others yeah bad understand.\nLearn machine report upon wish eat. These growth safe return wide strategy produce.",
+      "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
+      "created": "2019-01-24T17:00:20.068Z",
+      "updated": "2019-01-24T17:00:20.068Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 12,
+    "fields": {
+      "user": "391b3570-e10d-4ff9-86b3-906db57b3db5",
+      "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 40000,
+      "salary_max": 0,
+      "experience": 18,
+      "about": "Force social house institution although decision. Assume nor feel same prevent behavior. Society move suffer a gas let company.",
+      "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
+      "created": "2019-01-24T17:00:20.156Z",
+      "updated": "2019-01-24T17:00:20.156Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 13,
+    "fields": {
+      "user": "e5a22d40-faf8-47d4-9dfe-a557a1bec9c3",
+      "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+      "salary_min": 30000,
+      "salary_max": 60000,
+      "experience": 8,
+      "about": "Outside whom significant figure. Science charge fish they sign school get. Eye return get skill face pass.",
+      "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+      "created": "2019-01-24T17:00:20.234Z",
+      "updated": "2019-01-24T17:00:20.234Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 14,
+    "fields": {
+      "user": "22242431-d4c7-452c-8340-be143ca10563",
+      "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+      "salary_min": 0,
+      "salary_max": 80000,
+      "experience": 33,
+      "about": "Smile allow must available consumer individual see. While no house sure issue feeling room. Very more direction financial assume seem red way.\nDeal run issue. Door often pull.",
+      "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
+      "created": "2019-01-24T17:00:20.308Z",
+      "updated": "2019-01-24T17:00:20.308Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 15,
+    "fields": {
+      "user": "b2c71b21-2233-4706-9724-8e6989643f55",
+      "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+      "salary_min": 0,
+      "salary_max": 0,
+      "experience": 32,
+      "about": "Least able mean skin everyone successful. Until mouth chair apply there big.\nCharge hard relationship hour thousand painting admit. Small leave on meet. Upon manager within account figure support.",
+      "city": "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a",
+      "created": "2019-01-24T17:00:20.368Z",
+      "updated": "2019-01-24T17:00:20.368Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 16,
+    "fields": {
+      "user": "3246d967-415d-408e-8767-730061a4ea9d",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 0,
+      "salary_max": 80000,
+      "experience": 33,
+      "about": "Thus little quality choice which into kind political. South daughter smile Congress. Those station wife.",
+      "city": "\u041a\u0430\u0437\u0430\u043d\u044c",
+      "created": "2019-01-24T17:00:20.465Z",
+      "updated": "2019-01-24T17:00:20.465Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 17,
+    "fields": {
+      "user": "c1f68e43-3680-4f2a-a21d-c0897a75862b",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 40000,
+      "salary_max": 100000,
+      "experience": 35,
+      "about": "Power system positive herself story rather. Program owner think decade also individual eight. Until candidate middle perform. Floor court rest skill nature easy.",
+      "city": "\u041f\u0435\u0440\u043c\u044c",
+      "created": "2019-01-24T17:00:20.530Z",
+      "updated": "2019-01-24T17:00:20.530Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 18,
+    "fields": {
+      "user": "912e82b1-8903-4ef6-81dd-a2b81c8e9183",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 30000,
+      "salary_max": 60000,
+      "experience": 5,
+      "about": "Opportunity create participant so. Choose turn maintain consider bill miss prevent. National charge small decision list sure level economic.",
+      "city": "\u0421\u0430\u043c\u0430\u0440\u0430",
+      "created": "2019-01-24T17:00:20.614Z",
+      "updated": "2019-01-24T17:00:20.614Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 19,
+    "fields": {
+      "user": "407f39a8-2349-4a06-bfbb-e6898479c14e",
+      "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+      "salary_min": 0,
+      "salary_max": 100000,
+      "experience": 12,
+      "about": "Very something perhaps season school shoulder no. Account detail us.\nRecently try space hold rest. Say plant main unit just be. Deal whether relate skill program management after.",
+      "city": "\u041d\u0438\u0436\u043d\u0438\u0439 \u041d\u043e\u0432\u0433\u043e\u0440\u043e\u0434",
+      "created": "2019-01-24T17:00:20.682Z",
+      "updated": "2019-01-24T17:00:20.682Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 20,
+    "fields": {
+      "user": "912fb078-aa37-4016-b9ee-23a3b93b0182",
+      "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 50000,
+      "salary_max": 60000,
+      "experience": 18,
+      "about": "Up ten moment between personal alone economy. Particularly also detail trip training throw. Buy kind technology try trip. Large through establish natural.",
+      "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+      "created": "2019-01-24T17:00:20.731Z",
+      "updated": "2019-01-24T17:00:20.731Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 21,
+    "fields": {
+      "user": "814ad95c-886b-4d0d-b6eb-c34f47d22dd7",
+      "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 40000,
+      "salary_max": 0,
+      "experience": 9,
+      "about": "Describe out from play situation sure agreement they. People city short policy section director. Realize administration there remain.",
+      "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
+      "created": "2019-01-24T17:00:20.807Z",
+      "updated": "2019-01-24T17:00:20.807Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 22,
+    "fields": {
+      "user": "2cface48-0692-4ed6-9948-3de353dea7a1",
+      "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 0,
+      "salary_max": 80000,
+      "experience": 32,
+      "about": "Hope quickly happen box own meeting. Learn art relationship know school.\nOpen why surface hold different indicate moment. Year song thank work much.",
+      "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
+      "created": "2019-01-24T17:00:20.867Z",
+      "updated": "2019-01-24T17:00:20.867Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 23,
+    "fields": {
+      "user": "5d0d9479-d451-45f6-82d6-3cd8759b3fe4",
+      "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 50000,
+      "salary_max": 0,
+      "experience": 9,
+      "about": "See yes material during physical our federal deal. And focus loss green. Spend police mother large.\nInside lot floor. Your line back share.",
+      "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
+      "created": "2019-01-24T17:00:20.925Z",
+      "updated": "2019-01-24T17:00:20.925Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 24,
+    "fields": {
+      "user": "62707eb9-4fa5-481f-b554-58ecabb8e4db",
+      "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 30000,
+      "salary_max": 80000,
+      "experience": 15,
+      "about": "Member defense part our of rate should. Example high reason occur machine forward edge main. Single name day truth interesting. According one choose long life.",
+      "city": "\u041f\u0435\u0440\u043c\u044c",
+      "created": "2019-01-24T17:00:20.997Z",
+      "updated": "2019-01-24T17:00:20.997Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 25,
+    "fields": {
+      "user": "81e1eef3-c5af-447e-9313-03cd84a2fc34",
+      "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 40000,
+      "salary_max": 100000,
+      "experience": 13,
+      "about": "Letter table that heart. Member pay or shake baby.\nParticipant often effort director source about. Exactly its red player performance. Each the play animal coach your.",
+      "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+      "created": "2019-01-24T17:00:21.069Z",
+      "updated": "2019-01-24T17:00:21.069Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 26,
+    "fields": {
+      "user": "25db6356-51c9-470f-904c-eaedd8b8b6c3",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 0,
+      "salary_max": 0,
+      "experience": 30,
+      "about": "Turn person some any forward already represent figure. Imagine entire appear term support despite apply.",
+      "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
+      "created": "2019-01-24T17:00:21.148Z",
+      "updated": "2019-01-24T17:00:21.148Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 27,
+    "fields": {
+      "user": "3e660cbd-a9ba-4e46-b3e6-7d1a9e89b62f",
+      "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 30000,
+      "salary_max": 100000,
+      "experience": 23,
+      "about": "Foreign before then when eye. Describe former official history court task actually.\nHope with fire action. Force spring white minute section energy visit point.",
+      "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
+      "created": "2019-01-24T17:00:21.203Z",
+      "updated": "2019-01-24T17:00:21.203Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 28,
+    "fields": {
+      "user": "c91b5c44-07ed-4378-b6d1-57f6215300eb",
+      "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 50000,
+      "salary_max": 60000,
+      "experience": 4,
+      "about": "People there station sea idea. Tree never light standard. Easy form join among yard explain.",
+      "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
+      "created": "2019-01-24T17:00:21.272Z",
+      "updated": "2019-01-24T17:00:21.272Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 29,
+    "fields": {
+      "user": "8f256228-7ebe-48af-8fe8-7db3e8ae145b",
+      "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 0,
+      "salary_max": 80000,
+      "experience": 0,
+      "about": "What sister describe already majority behavior. Meeting fish talk improve. Remain power ability media think.",
+      "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
+      "created": "2019-01-24T17:00:21.326Z",
+      "updated": "2019-01-24T17:00:21.326Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 30,
+    "fields": {
+      "user": "d2551fc6-05ef-424b-b5b2-9c37a1726342",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 30000,
+      "salary_max": 0,
+      "experience": 5,
+      "about": "Change teach owner book. Early street hard also. Spend experience main purpose thank try certainly risk.\nWe senior summer standard put. Upon western wrong really card appear interesting.",
+      "city": "\u0423\u0444\u0430",
+      "created": "2019-01-24T17:00:21.392Z",
+      "updated": "2019-01-24T17:00:21.392Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 31,
+    "fields": {
+      "user": "3f00d479-526a-4c48-bfae-8d30387c3486",
+      "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
+      "salary_min": 40000,
+      "salary_max": 100000,
+      "experience": 14,
+      "about": "Month measure where what my stop. Design face officer team.\nUnderstand near at team occur him. Avoid yard image black. Law nature only make pull hit.",
+      "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
+      "created": "2019-01-24T17:00:21.447Z",
+      "updated": "2019-01-24T17:00:21.447Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 32,
+    "fields": {
+      "user": "31627a80-4fcd-445a-957a-35649bf3f9c9",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 40000,
+      "salary_max": 80000,
+      "experience": 3,
+      "about": "Beat main country very story they teacher. Chair because voice can respond. Decade customer experience whatever test could song.",
+      "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
+      "created": "2019-01-24T17:00:21.508Z",
+      "updated": "2019-01-24T17:00:21.508Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 33,
+    "fields": {
+      "user": "4cd32212-b689-424d-a4e1-15f820f41699",
+      "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+      "salary_min": 50000,
+      "salary_max": 80000,
+      "experience": 30,
+      "about": "Scene next management point big. Material store number education house.\nBefore reduce save. Then total television each put.",
+      "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
+      "created": "2019-01-24T17:00:21.583Z",
+      "updated": "2019-01-24T17:00:21.583Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 34,
+    "fields": {
+      "user": "91454ef0-361c-48d7-8c2c-44e1b9214b37",
+      "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 50000,
+      "salary_max": 100000,
+      "experience": 9,
+      "about": "Special during record pressure raise edge. Fly according read upon discussion recently herself.",
+      "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
+      "created": "2019-01-24T17:00:21.658Z",
+      "updated": "2019-01-24T17:00:21.658Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 35,
+    "fields": {
+      "user": "84cfd42a-6f8c-48a5-a78a-833fc48e10a9",
+      "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
+      "salary_min": 50000,
+      "salary_max": 80000,
+      "experience": 0,
+      "about": "Plan history tax fear into church character. Series often reveal less paper.\nInterview somebody thing call partner price others. Standard improve within artist information program small.",
+      "city": "\u0412\u043e\u0440\u043e\u043d\u0435\u0436",
+      "created": "2019-01-24T17:00:21.719Z",
+      "updated": "2019-01-24T17:00:21.719Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 36,
+    "fields": {
+      "user": "81bd24c0-551c-408b-8a78-af2e1f4d0eca",
+      "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
+      "salary_min": 40000,
+      "salary_max": 80000,
+      "experience": 23,
+      "about": "Minute sense fire always be including. Argue record chair popular. Mother since bag decade talk black last.",
+      "city": "\u041a\u0430\u0437\u0430\u043d\u044c",
+      "created": "2019-01-24T17:00:21.782Z",
+      "updated": "2019-01-24T17:00:21.782Z"
+    }
+  },
+  {
+    "model": "resumes.resume",
+    "pk": 37,
+    "fields": {
+      "user": "fa4a6c3d-fa6a-4633-8045-35f47d6f1a0b",
+      "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
+      "salary_min": 50000,
+      "salary_max": 100000,
+      "experience": 35,
+      "about": "Message myself form doctor. Beautiful hair paper reality through have attorney big. Cost until another.\nFew available imagine wish least. By skill teacher total. Create street message rather inside.",
+      "city": "\u041f\u0435\u0440\u043c\u044c",
+      "created": "2019-01-24T17:00:21.851Z",
+      "updated": "2019-01-24T17:00:21.851Z"
+    }
   }
-},
-{
-  "model": "users.user",
-  "pk": "25db6356-51c9-470f-904c-eaedd8b8b6c3",
-  "fields": {
-    "password": "qVmiXQNghsaoBQYdtark",
-    "last_login": null,
-    "email": "jodilowery@williams.com",
-    "first_name": "Sarah",
-    "last_name": "Morgan",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.109Z",
-    "updated": "2019-01-24T17:00:21.109Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "2cface48-0692-4ed6-9948-3de353dea7a1",
-  "fields": {
-    "password": "McCFrRUqGOWKndBLRNEH",
-    "last_login": null,
-    "email": "sgomez@gmail.com",
-    "first_name": "Mary",
-    "last_name": "Costa",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.835Z",
-    "updated": "2019-01-24T17:00:20.835Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "30fb16c2-58e0-4c1c-8d7e-f75b2ac0a0d4",
-  "fields": {
-    "password": "BrDfWCGfWFLmqvlfrtcj",
-    "last_login": null,
-    "email": "afriedman@yahoo.com",
-    "first_name": "William",
-    "last_name": "Richardson",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.036Z",
-    "updated": "2019-01-24T17:00:20.036Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "31627a80-4fcd-445a-957a-35649bf3f9c9",
-  "fields": {
-    "password": "jrEjiMxPyafZHKQlXyLa",
-    "last_login": null,
-    "email": "kathryn97@jones-collins.com",
-    "first_name": "Jeremy",
-    "last_name": "Lynch",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.485Z",
-    "updated": "2019-01-24T17:00:21.485Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "322baa71-89dc-414f-a03a-fb45a32a87b8",
-  "fields": {
-    "password": "sdLOsQPetsExfqBvPEkT",
-    "last_login": null,
-    "email": "nchapman@gmail.com",
-    "first_name": "John",
-    "last_name": "Turner",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.914Z",
-    "updated": "2019-01-24T17:00:19.914Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "3246d967-415d-408e-8767-730061a4ea9d",
-  "fields": {
-    "password": "cdTOegpXjyBzZNyUMjQN",
-    "last_login": null,
-    "email": "samanthaerickson@hotmail.com",
-    "first_name": "Anthony",
-    "last_name": "Adams",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.424Z",
-    "updated": "2019-01-24T17:00:20.424Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "391b3570-e10d-4ff9-86b3-906db57b3db5",
-  "fields": {
-    "password": "oqpIFzcYjDkUdrBXtTAj",
-    "last_login": null,
-    "email": "zgould@clark-stone.com",
-    "first_name": "Christopher",
-    "last_name": "Moore",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.112Z",
-    "updated": "2019-01-24T17:00:20.112Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "3e660cbd-a9ba-4e46-b3e6-7d1a9e89b62f",
-  "fields": {
-    "password": "lRZKlRjZNDLxfgMiIqHh",
-    "last_login": null,
-    "email": "heidiweiss@gray-harper.com",
-    "first_name": "Glenda",
-    "last_name": "Morgan",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.173Z",
-    "updated": "2019-01-24T17:00:21.173Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "3f00d479-526a-4c48-bfae-8d30387c3486",
-  "fields": {
-    "password": "esusiRrjejCbZoixhBhB",
-    "last_login": null,
-    "email": "uromero@miller.com",
-    "first_name": "Shawn",
-    "last_name": "Matthews",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.423Z",
-    "updated": "2019-01-24T17:00:21.423Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "407f39a8-2349-4a06-bfbb-e6898479c14e",
-  "fields": {
-    "password": "TivgBCJhSavBXexDXlxb",
-    "last_login": null,
-    "email": "thill@martin.info",
-    "first_name": "Kevin",
-    "last_name": "Bernard",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.646Z",
-    "updated": "2019-01-24T17:00:20.646Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "4cd32212-b689-424d-a4e1-15f820f41699",
-  "fields": {
-    "password": "NgcBNxzmnBMEvdtHAlSD",
-    "last_login": null,
-    "email": "elizabeth62@armstrong-oliver.net",
-    "first_name": "Miguel",
-    "last_name": "Dean",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.544Z",
-    "updated": "2019-01-24T17:00:21.544Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "57a3de9d-1ea2-45ae-ab65-6e1b895781c0",
-  "fields": {
-    "password": "qdUVQLvxjAMGNByAvtee",
-    "last_login": null,
-    "email": "velasquezangela@ortiz.info",
-    "first_name": "Alan",
-    "last_name": "Kim",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.618Z",
-    "updated": "2019-01-24T17:00:19.618Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "57c259d9-2e10-4de9-9ed0-7a21071c467d",
-  "fields": {
-    "password": "xEgzLpCAwCqQiaNsGcUy",
-    "last_login": null,
-    "email": "fmckinney@bauer.biz",
-    "first_name": "Kimberly",
-    "last_name": "Jones",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.424Z",
-    "updated": "2019-01-24T17:00:19.424Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "5d0d9479-d451-45f6-82d6-3cd8759b3fe4",
-  "fields": {
-    "password": "BnYZxMwDTGUoFPqXodGL",
-    "last_login": null,
-    "email": "davidwright@hotmail.com",
-    "first_name": "Kevin",
-    "last_name": "Brown",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.899Z",
-    "updated": "2019-01-24T17:00:20.899Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "62707eb9-4fa5-481f-b554-58ecabb8e4db",
-  "fields": {
-    "password": "AidyRQyDpPdZIkdvNaqu",
-    "last_login": null,
-    "email": "wholmes@yahoo.com",
-    "first_name": "Carolyn",
-    "last_name": "Harrington",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.967Z",
-    "updated": "2019-01-24T17:00:20.967Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "682ef4bf-65bd-4920-8a20-8b1262c3f4d5",
-  "fields": {
-    "password": "NDaJMAqFbInVwZfmNMEe",
-    "last_login": null,
-    "email": "martinezmary@yahoo.com",
-    "first_name": "Ryan",
-    "last_name": "Murray",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.792Z",
-    "updated": "2019-01-24T17:00:19.792Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "814ad95c-886b-4d0d-b6eb-c34f47d22dd7",
-  "fields": {
-    "password": "ohoKIZICrbhAkozwlOlN",
-    "last_login": null,
-    "email": "brandolph@kent.com",
-    "first_name": "Daniel",
-    "last_name": "Hopkins",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.770Z",
-    "updated": "2019-01-24T17:00:20.770Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "81bd24c0-551c-408b-8a78-af2e1f4d0eca",
-  "fields": {
-    "password": "ZDgpHAQSfHCopxzElcmZ",
-    "last_login": null,
-    "email": "jeff87@gomez.com",
-    "first_name": "Chelsea",
-    "last_name": "Turner",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.749Z",
-    "updated": "2019-01-24T17:00:21.749Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "81e1eef3-c5af-447e-9313-03cd84a2fc34",
-  "fields": {
-    "password": "uiFRurVBEgCyetBppEAY",
-    "last_login": null,
-    "email": "umoore@moore.com",
-    "first_name": "Howard",
-    "last_name": "Farmer",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.044Z",
-    "updated": "2019-01-24T17:00:21.044Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "845c0548-f812-4030-be3e-aff469764976",
-  "fields": {
-    "password": "ZFxxCjOBNDMheDKlfBvg",
-    "last_login": null,
-    "email": "luis60@stephenson.com",
-    "first_name": "Christina",
-    "last_name": "Pham",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.490Z",
-    "updated": "2019-01-24T17:00:19.490Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "84cfd42a-6f8c-48a5-a78a-833fc48e10a9",
-  "fields": {
-    "password": "EzNoxhzUQywApMOWtsyE",
-    "last_login": null,
-    "email": "crystal12@martinez.com",
-    "first_name": "Samuel",
-    "last_name": "Delgado",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.691Z",
-    "updated": "2019-01-24T17:00:21.691Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "8d346fb9-1401-4056-8865-ff92d221a6fb",
-  "fields": {
-    "password": "xtMIxiEMUfzEcguGVAAd",
-    "last_login": null,
-    "email": "thomasarcher@walter.com",
-    "first_name": "Michael",
-    "last_name": "Chung",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.967Z",
-    "updated": "2019-01-24T17:00:19.967Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "8f256228-7ebe-48af-8fe8-7db3e8ae145b",
-  "fields": {
-    "password": "xCbEsWfjeSqBhMUMZtHR",
-    "last_login": null,
-    "email": "john74@gutierrez.com",
-    "first_name": "Joseph",
-    "last_name": "Lewis",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.300Z",
-    "updated": "2019-01-24T17:00:21.300Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "912e82b1-8903-4ef6-81dd-a2b81c8e9183",
-  "fields": {
-    "password": "wLsoNzLknZBzqoXuVbys",
-    "last_login": null,
-    "email": "drowe@hotmail.com",
-    "first_name": "Alyssa",
-    "last_name": "Chapman",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.562Z",
-    "updated": "2019-01-24T17:00:20.562Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "912fb078-aa37-4016-b9ee-23a3b93b0182",
-  "fields": {
-    "password": "ftXlUSojSDnuWPGJhgVS",
-    "last_login": null,
-    "email": "william43@hotmail.com",
-    "first_name": "Mark",
-    "last_name": "Carpenter",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.705Z",
-    "updated": "2019-01-24T17:00:20.705Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "91454ef0-361c-48d7-8c2c-44e1b9214b37",
-  "fields": {
-    "password": "PPrZiEfrKPbRyTHpkphk",
-    "last_login": null,
-    "email": "robersonhannah@gmail.com",
-    "first_name": "Christina",
-    "last_name": "Oconnell",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.620Z",
-    "updated": "2019-01-24T17:00:21.620Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "a7689be9-68c4-4cd3-bf21-2fb62053a44d",
-  "fields": {
-    "password": "GMvdDUOvdONspwNJFgXG",
-    "last_login": null,
-    "email": "powelldenise@lewis.com",
-    "first_name": "Karina",
-    "last_name": "Jones",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.555Z",
-    "updated": "2019-01-24T17:00:19.555Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "b2c71b21-2233-4706-9724-8e6989643f55",
-  "fields": {
-    "password": "UPjpWFEKLFYANMKVDKko",
-    "last_login": null,
-    "email": "kristinflores@miranda-miles.com",
-    "first_name": "Frank",
-    "last_name": "Turner",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.339Z",
-    "updated": "2019-01-24T17:00:20.339Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "bd2fa856-d29c-4e09-9ab8-a83c53b18e21",
-  "fields": {
-    "password": "QiTWEBXTlrGiKiogWdVP",
-    "last_login": null,
-    "email": "stephanieharmon@yahoo.com",
-    "first_name": "Carrie",
-    "last_name": "Gonzalez",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.844Z",
-    "updated": "2019-01-24T17:00:19.844Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "bda692b1-1148-4f5a-aa6f-cfd66121f4f1",
-  "fields": {
-    "password": "kXKWEigsiXEDhVZmimGm",
-    "last_login": null,
-    "email": "conleydeborah@perry.biz",
-    "first_name": "Kimberly",
-    "last_name": "Moore",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.673Z",
-    "updated": "2019-01-24T17:00:19.673Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "c1f68e43-3680-4f2a-a21d-c0897a75862b",
-  "fields": {
-    "password": "coTLMzSQLMuqwxpXhLvW",
-    "last_login": null,
-    "email": "imclaughlin@gmail.com",
-    "first_name": "Denise",
-    "last_name": "Campbell",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.503Z",
-    "updated": "2019-01-24T17:00:20.503Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "c91b5c44-07ed-4378-b6d1-57f6215300eb",
-  "fields": {
-    "password": "eFoQfLttEZpxNOSOQSan",
-    "last_login": null,
-    "email": "sharonjohnson@gmail.com",
-    "first_name": "Jason",
-    "last_name": "Andrade",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.241Z",
-    "updated": "2019-01-24T17:00:21.241Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "d2551fc6-05ef-424b-b5b2-9c37a1726342",
-  "fields": {
-    "password": "HkDxxLJUleqYRGWhNtxe",
-    "last_login": null,
-    "email": "raymond71@gmail.com",
-    "first_name": "Jason",
-    "last_name": "Williams",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.369Z",
-    "updated": "2019-01-24T17:00:21.369Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "e1a0e808-eb60-4052-b5cf-1900011de35f",
-  "fields": {
-    "password": "PEEyylsKIpEIPZTAHkIF",
-    "last_login": null,
-    "email": "ruthnolan@mitchell-sims.com",
-    "first_name": "Michelle",
-    "last_name": "Savage",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:19.724Z",
-    "updated": "2019-01-24T17:00:19.724Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "e5a22d40-faf8-47d4-9dfe-a557a1bec9c3",
-  "fields": {
-    "password": "ZyeXWWQypLUswupZLsfR",
-    "last_login": null,
-    "email": "markjohnson@yahoo.com",
-    "first_name": "Candice",
-    "last_name": "Craig",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:20.194Z",
-    "updated": "2019-01-24T17:00:20.194Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "users.user",
-  "pk": "fa4a6c3d-fa6a-4633-8045-35f47d6f1a0b",
-  "fields": {
-    "password": "UsVDHmUVQpnehEdOvQLg",
-    "last_login": null,
-    "email": "sheryl57@rivera.com",
-    "first_name": "Jared",
-    "last_name": "Mendoza",
-    "date_of_birth": null,
-    "date_joined": "2019-01-24T17:00:21.819Z",
-    "updated": "2019-01-24T17:00:21.819Z",
-    "is_active": true,
-    "is_staff": false,
-    "is_superuser": false,
-    "is_employer": false,
-    "is_seeker": false,
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 1,
-  "fields": {
-    "user": "57c259d9-2e10-4de9-9ed0-7a21071c467d",
-    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
-    "salary_min": 0,
-    "salary_max": 80000,
-    "experience": 26,
-    "about": "Threat eight culture front safe same reason understand. Agreement night minute notice.\nBehind political edge one matter bed serve over. Democratic service baby light family office member.",
-    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
-    "created": "2019-01-24T17:00:19.452Z",
-    "updated": "2019-01-24T17:00:19.452Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 2,
-  "fields": {
-    "user": "845c0548-f812-4030-be3e-aff469764976",
-    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 30000,
-    "salary_max": 0,
-    "experience": 8,
-    "about": "Its increase form town along machine environmental. Job lose less fall deal. Together against pick forward outside simple modern.",
-    "city": "\u041f\u0435\u0440\u043c\u044c",
-    "created": "2019-01-24T17:00:19.520Z",
-    "updated": "2019-01-24T17:00:19.520Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 3,
-  "fields": {
-    "user": "a7689be9-68c4-4cd3-bf21-2fb62053a44d",
-    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 30000,
-    "salary_max": 60000,
-    "experience": 1,
-    "about": "Indeed according mean particular second after. Else lose create born part. Force situation us.",
-    "city": "\u0412\u043e\u0440\u043e\u043d\u0435\u0436",
-    "created": "2019-01-24T17:00:19.594Z",
-    "updated": "2019-01-24T17:00:19.594Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 4,
-  "fields": {
-    "user": "57a3de9d-1ea2-45ae-ab65-6e1b895781c0",
-    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
-    "salary_min": 40000,
-    "salary_max": 60000,
-    "experience": 21,
-    "about": "Respond someone last first leg. Down strategy often land reach type. Process long check middle. Various commercial speech night.",
-    "city": "\u041e\u043c\u0441\u043a",
-    "created": "2019-01-24T17:00:19.644Z",
-    "updated": "2019-01-24T17:00:19.644Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 5,
-  "fields": {
-    "user": "bda692b1-1148-4f5a-aa6f-cfd66121f4f1",
-    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
-    "salary_min": 40000,
-    "salary_max": 60000,
-    "experience": 15,
-    "about": "Event sport but play certain now option. East whether this activity couple. Sea better offer woman simply person.",
-    "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
-    "created": "2019-01-24T17:00:19.698Z",
-    "updated": "2019-01-24T17:00:19.698Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 6,
-  "fields": {
-    "user": "e1a0e808-eb60-4052-b5cf-1900011de35f",
-    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 0,
-    "salary_max": 80000,
-    "experience": 23,
-    "about": "Politics recent team doctor type able only. Physical cultural long major. Direction show administration including.",
-    "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
-    "created": "2019-01-24T17:00:19.755Z",
-    "updated": "2019-01-24T17:00:19.756Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 7,
-  "fields": {
-    "user": "682ef4bf-65bd-4920-8a20-8b1262c3f4d5",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 50000,
-    "salary_max": 80000,
-    "experience": 12,
-    "about": "Sometimes remain three. Cell single white case nature.\nTree phone idea really. Meeting piece alone provide while scene. Need total season travel tend reason.",
-    "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
-    "created": "2019-01-24T17:00:19.818Z",
-    "updated": "2019-01-24T17:00:19.818Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 8,
-  "fields": {
-    "user": "bd2fa856-d29c-4e09-9ab8-a83c53b18e21",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 40000,
-    "salary_max": 0,
-    "experience": 5,
-    "about": "Still seat street room reason trade. Allow affect we. Eye car part image ability.\nBar my first land price. Cultural off reason happen all. Myself really half hold choice hard a.",
-    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
-    "created": "2019-01-24T17:00:19.886Z",
-    "updated": "2019-01-24T17:00:19.886Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 9,
-  "fields": {
-    "user": "322baa71-89dc-414f-a03a-fb45a32a87b8",
-    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 0,
-    "salary_max": 80000,
-    "experience": 7,
-    "about": "Stage which two three enjoy change build. Center blue blood buy.\nOrganization soon after value. Question give myself car when civil.",
-    "city": "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a",
-    "created": "2019-01-24T17:00:19.941Z",
-    "updated": "2019-01-24T17:00:19.941Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 10,
-  "fields": {
-    "user": "8d346fb9-1401-4056-8865-ff92d221a6fb",
-    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 40000,
-    "salary_max": 100000,
-    "experience": 9,
-    "about": "Hold only exist and skill same pull. Phone teacher southern right type. So size put exist. Cause pass herself when kind.\nPlace newspaper people popular. Woman between Republican care.",
-    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
-    "created": "2019-01-24T17:00:19.993Z",
-    "updated": "2019-01-24T17:00:19.993Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 11,
-  "fields": {
-    "user": "30fb16c2-58e0-4c1c-8d7e-f75b2ac0a0d4",
-    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
-    "salary_min": 0,
-    "salary_max": 0,
-    "experience": 24,
-    "about": "West official fish realize down area might argue. Avoid others yeah bad understand.\nLearn machine report upon wish eat. These growth safe return wide strategy produce.",
-    "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
-    "created": "2019-01-24T17:00:20.068Z",
-    "updated": "2019-01-24T17:00:20.068Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 12,
-  "fields": {
-    "user": "391b3570-e10d-4ff9-86b3-906db57b3db5",
-    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 40000,
-    "salary_max": 0,
-    "experience": 18,
-    "about": "Force social house institution although decision. Assume nor feel same prevent behavior. Society move suffer a gas let company.",
-    "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
-    "created": "2019-01-24T17:00:20.156Z",
-    "updated": "2019-01-24T17:00:20.156Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 13,
-  "fields": {
-    "user": "e5a22d40-faf8-47d4-9dfe-a557a1bec9c3",
-    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
-    "salary_min": 30000,
-    "salary_max": 60000,
-    "experience": 8,
-    "about": "Outside whom significant figure. Science charge fish they sign school get. Eye return get skill face pass.",
-    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
-    "created": "2019-01-24T17:00:20.234Z",
-    "updated": "2019-01-24T17:00:20.234Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 14,
-  "fields": {
-    "user": "22242431-d4c7-452c-8340-be143ca10563",
-    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
-    "salary_min": 0,
-    "salary_max": 80000,
-    "experience": 33,
-    "about": "Smile allow must available consumer individual see. While no house sure issue feeling room. Very more direction financial assume seem red way.\nDeal run issue. Door often pull.",
-    "city": "\u041d\u043e\u0432\u043e\u0441\u0438\u0431\u0438\u0440\u0441\u043a",
-    "created": "2019-01-24T17:00:20.308Z",
-    "updated": "2019-01-24T17:00:20.308Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 15,
-  "fields": {
-    "user": "b2c71b21-2233-4706-9724-8e6989643f55",
-    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
-    "salary_min": 0,
-    "salary_max": 0,
-    "experience": 32,
-    "about": "Least able mean skin everyone successful. Until mouth chair apply there big.\nCharge hard relationship hour thousand painting admit. Small leave on meet. Upon manager within account figure support.",
-    "city": "\u041a\u0440\u0430\u0441\u043d\u043e\u044f\u0440\u0441\u043a",
-    "created": "2019-01-24T17:00:20.368Z",
-    "updated": "2019-01-24T17:00:20.368Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 16,
-  "fields": {
-    "user": "3246d967-415d-408e-8767-730061a4ea9d",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 0,
-    "salary_max": 80000,
-    "experience": 33,
-    "about": "Thus little quality choice which into kind political. South daughter smile Congress. Those station wife.",
-    "city": "\u041a\u0430\u0437\u0430\u043d\u044c",
-    "created": "2019-01-24T17:00:20.465Z",
-    "updated": "2019-01-24T17:00:20.465Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 17,
-  "fields": {
-    "user": "c1f68e43-3680-4f2a-a21d-c0897a75862b",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 40000,
-    "salary_max": 100000,
-    "experience": 35,
-    "about": "Power system positive herself story rather. Program owner think decade also individual eight. Until candidate middle perform. Floor court rest skill nature easy.",
-    "city": "\u041f\u0435\u0440\u043c\u044c",
-    "created": "2019-01-24T17:00:20.530Z",
-    "updated": "2019-01-24T17:00:20.530Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 18,
-  "fields": {
-    "user": "912e82b1-8903-4ef6-81dd-a2b81c8e9183",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 30000,
-    "salary_max": 60000,
-    "experience": 5,
-    "about": "Opportunity create participant so. Choose turn maintain consider bill miss prevent. National charge small decision list sure level economic.",
-    "city": "\u0421\u0430\u043c\u0430\u0440\u0430",
-    "created": "2019-01-24T17:00:20.614Z",
-    "updated": "2019-01-24T17:00:20.614Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 19,
-  "fields": {
-    "user": "407f39a8-2349-4a06-bfbb-e6898479c14e",
-    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
-    "salary_min": 0,
-    "salary_max": 100000,
-    "experience": 12,
-    "about": "Very something perhaps season school shoulder no. Account detail us.\nRecently try space hold rest. Say plant main unit just be. Deal whether relate skill program management after.",
-    "city": "\u041d\u0438\u0436\u043d\u0438\u0439 \u041d\u043e\u0432\u0433\u043e\u0440\u043e\u0434",
-    "created": "2019-01-24T17:00:20.682Z",
-    "updated": "2019-01-24T17:00:20.682Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 20,
-  "fields": {
-    "user": "912fb078-aa37-4016-b9ee-23a3b93b0182",
-    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 50000,
-    "salary_max": 60000,
-    "experience": 18,
-    "about": "Up ten moment between personal alone economy. Particularly also detail trip training throw. Buy kind technology try trip. Large through establish natural.",
-    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
-    "created": "2019-01-24T17:00:20.731Z",
-    "updated": "2019-01-24T17:00:20.731Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 21,
-  "fields": {
-    "user": "814ad95c-886b-4d0d-b6eb-c34f47d22dd7",
-    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 40000,
-    "salary_max": 0,
-    "experience": 9,
-    "about": "Describe out from play situation sure agreement they. People city short policy section director. Realize administration there remain.",
-    "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
-    "created": "2019-01-24T17:00:20.807Z",
-    "updated": "2019-01-24T17:00:20.807Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 22,
-  "fields": {
-    "user": "2cface48-0692-4ed6-9948-3de353dea7a1",
-    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 0,
-    "salary_max": 80000,
-    "experience": 32,
-    "about": "Hope quickly happen box own meeting. Learn art relationship know school.\nOpen why surface hold different indicate moment. Year song thank work much.",
-    "city": "\u0427\u0435\u043b\u044f\u0431\u0438\u043d\u0441\u043a",
-    "created": "2019-01-24T17:00:20.867Z",
-    "updated": "2019-01-24T17:00:20.867Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 23,
-  "fields": {
-    "user": "5d0d9479-d451-45f6-82d6-3cd8759b3fe4",
-    "position": "\u0433\u043b. \u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 50000,
-    "salary_max": 0,
-    "experience": 9,
-    "about": "See yes material during physical our federal deal. And focus loss green. Spend police mother large.\nInside lot floor. Your line back share.",
-    "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
-    "created": "2019-01-24T17:00:20.925Z",
-    "updated": "2019-01-24T17:00:20.925Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 24,
-  "fields": {
-    "user": "62707eb9-4fa5-481f-b554-58ecabb8e4db",
-    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 30000,
-    "salary_max": 80000,
-    "experience": 15,
-    "about": "Member defense part our of rate should. Example high reason occur machine forward edge main. Single name day truth interesting. According one choose long life.",
-    "city": "\u041f\u0435\u0440\u043c\u044c",
-    "created": "2019-01-24T17:00:20.997Z",
-    "updated": "2019-01-24T17:00:20.997Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 25,
-  "fields": {
-    "user": "81e1eef3-c5af-447e-9313-03cd84a2fc34",
-    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 40000,
-    "salary_max": 100000,
-    "experience": 13,
-    "about": "Letter table that heart. Member pay or shake baby.\nParticipant often effort director source about. Exactly its red player performance. Each the play animal coach your.",
-    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
-    "created": "2019-01-24T17:00:21.069Z",
-    "updated": "2019-01-24T17:00:21.069Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 26,
-  "fields": {
-    "user": "25db6356-51c9-470f-904c-eaedd8b8b6c3",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 0,
-    "salary_max": 0,
-    "experience": 30,
-    "about": "Turn person some any forward already represent figure. Imagine entire appear term support despite apply.",
-    "city": "\u041c\u043e\u0441\u043a\u0432\u0430",
-    "created": "2019-01-24T17:00:21.148Z",
-    "updated": "2019-01-24T17:00:21.148Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 27,
-  "fields": {
-    "user": "3e660cbd-a9ba-4e46-b3e6-7d1a9e89b62f",
-    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 30000,
-    "salary_max": 100000,
-    "experience": 23,
-    "about": "Foreign before then when eye. Describe former official history court task actually.\nHope with fire action. Force spring white minute section energy visit point.",
-    "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
-    "created": "2019-01-24T17:00:21.203Z",
-    "updated": "2019-01-24T17:00:21.203Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 28,
-  "fields": {
-    "user": "c91b5c44-07ed-4378-b6d1-57f6215300eb",
-    "position": "\u0433\u043b. \u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 50000,
-    "salary_max": 60000,
-    "experience": 4,
-    "about": "People there station sea idea. Tree never light standard. Easy form join among yard explain.",
-    "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
-    "created": "2019-01-24T17:00:21.272Z",
-    "updated": "2019-01-24T17:00:21.272Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 29,
-  "fields": {
-    "user": "8f256228-7ebe-48af-8fe8-7db3e8ae145b",
-    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 0,
-    "salary_max": 80000,
-    "experience": 0,
-    "about": "What sister describe already majority behavior. Meeting fish talk improve. Remain power ability media think.",
-    "city": "\u0421\u0430\u043d\u043a\u0442-\u041f\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433",
-    "created": "2019-01-24T17:00:21.326Z",
-    "updated": "2019-01-24T17:00:21.326Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 30,
-  "fields": {
-    "user": "d2551fc6-05ef-424b-b5b2-9c37a1726342",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 30000,
-    "salary_max": 0,
-    "experience": 5,
-    "about": "Change teach owner book. Early street hard also. Spend experience main purpose thank try certainly risk.\nWe senior summer standard put. Upon western wrong really card appear interesting.",
-    "city": "\u0423\u0444\u0430",
-    "created": "2019-01-24T17:00:21.392Z",
-    "updated": "2019-01-24T17:00:21.392Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 31,
-  "fields": {
-    "user": "3f00d479-526a-4c48-bfae-8d30387c3486",
-    "position": "\u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442",
-    "salary_min": 40000,
-    "salary_max": 100000,
-    "experience": 14,
-    "about": "Month measure where what my stop. Design face officer team.\nUnderstand near at team occur him. Avoid yard image black. Law nature only make pull hit.",
-    "city": "\u0412\u043e\u043b\u0433\u043e\u0433\u0440\u0430\u0434",
-    "created": "2019-01-24T17:00:21.447Z",
-    "updated": "2019-01-24T17:00:21.447Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 32,
-  "fields": {
-    "user": "31627a80-4fcd-445a-957a-35649bf3f9c9",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 40000,
-    "salary_max": 80000,
-    "experience": 3,
-    "about": "Beat main country very story they teacher. Chair because voice can respond. Decade customer experience whatever test could song.",
-    "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
-    "created": "2019-01-24T17:00:21.508Z",
-    "updated": "2019-01-24T17:00:21.508Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 33,
-  "fields": {
-    "user": "4cd32212-b689-424d-a4e1-15f820f41699",
-    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
-    "salary_min": 50000,
-    "salary_max": 80000,
-    "experience": 30,
-    "about": "Scene next management point big. Material store number education house.\nBefore reduce save. Then total television each put.",
-    "city": "\u0415\u043a\u0430\u0442\u0435\u0440\u0435\u043d\u0431\u0443\u0440\u0433",
-    "created": "2019-01-24T17:00:21.583Z",
-    "updated": "2019-01-24T17:00:21.583Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 34,
-  "fields": {
-    "user": "91454ef0-361c-48d7-8c2c-44e1b9214b37",
-    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 50000,
-    "salary_max": 100000,
-    "experience": 9,
-    "about": "Special during record pressure raise edge. Fly according read upon discussion recently herself.",
-    "city": "\u0420\u043e\u0441\u0442\u043e\u0432-\u043d\u0430-\u0414\u043e\u043d\u0443",
-    "created": "2019-01-24T17:00:21.658Z",
-    "updated": "2019-01-24T17:00:21.658Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 35,
-  "fields": {
-    "user": "84cfd42a-6f8c-48a5-a78a-833fc48e10a9",
-    "position": "\u0441\u0432\u0430\u0440\u0449\u0438\u043a",
-    "salary_min": 50000,
-    "salary_max": 80000,
-    "experience": 0,
-    "about": "Plan history tax fear into church character. Series often reveal less paper.\nInterview somebody thing call partner price others. Standard improve within artist information program small.",
-    "city": "\u0412\u043e\u0440\u043e\u043d\u0435\u0436",
-    "created": "2019-01-24T17:00:21.719Z",
-    "updated": "2019-01-24T17:00:21.719Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 36,
-  "fields": {
-    "user": "81bd24c0-551c-408b-8a78-af2e1f4d0eca",
-    "position": "\u0440\u0443\u043a\u043e\u0432\u043e\u0434\u0438\u0442\u0435\u043b\u044c \u0431\u0440\u0438\u0433\u0430\u0434\u044b",
-    "salary_min": 40000,
-    "salary_max": 80000,
-    "experience": 23,
-    "about": "Minute sense fire always be including. Argue record chair popular. Mother since bag decade talk black last.",
-    "city": "\u041a\u0430\u0437\u0430\u043d\u044c",
-    "created": "2019-01-24T17:00:21.782Z",
-    "updated": "2019-01-24T17:00:21.782Z"
-  }
-},
-{
-  "model": "resumes.resume",
-  "pk": 37,
-  "fields": {
-    "user": "fa4a6c3d-fa6a-4633-8045-35f47d6f1a0b",
-    "position": "\u0438\u043d\u0436\u0435\u043d\u0435\u0440",
-    "salary_min": 50000,
-    "salary_max": 100000,
-    "experience": 35,
-    "about": "Message myself form doctor. Beautiful hair paper reality through have attorney big. Cost until another.\nFew available imagine wish least. By skill teacher total. Create street message rather inside.",
-    "city": "\u041f\u0435\u0440\u043c\u044c",
-    "created": "2019-01-24T17:00:21.851Z",
-    "updated": "2019-01-24T17:00:21.851Z"
-  }
-}
 ]


### PR DESCRIPTION
Первая реализация резюме. Модель резюме пока максимально упрощенная, определенно требующая дальнейшего расширения и обсуждения. Однако, базовый функционал по созданию и показу резюме реализован. Верстка тоже примитивная, т.к. пока нет дизайна. Также добавлена реализация показа резюме на главной странице и начальная версия личного кабинета.

Для желающих посмотреть, как это выглядит в живую, приложил дамп с некоторым количеством фейково сгенерированных резюме. Дамп называется `users_resume_dump.json`, чтобы подгрузить его в БД, используйте команду:

```
python manage.py loaddata users_resume_dump.json
```

Еще для тестов подтянул библиотеку `mixer` (https://github.com/klen/mixer). Чтобы тесты проходили, нужно ее доставить. Она добавленна в `requirements.txt`, поэтому просто вновь запустите команду `pip install -r requirements.txt`.

Весь код данного пулл-реквеста, как обычно, покрыт тестами. Но это не исключает возможности наличия багов, так что проверяйте.