### PR TITLE
Переход на postgresql и добавление поиска резюме

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ package-lock.json
 venv
 geckodriver.log
 /static
+whoosh_index/

--- a/bewelder_redesign/settings.py
+++ b/bewelder_redesign/settings.py
@@ -82,9 +82,17 @@ WSGI_APPLICATION = 'bewelder_redesign.wsgi.application'
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
 DATABASES = {
+    # 'default': {
+    #     'ENGINE': 'django.db.backends.sqlite3',
+    #     'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    # }
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'bewgb_db',
+        'USER': 'bewgb_user',
+        'PASSWORD': 'password',
+        'HOST': 'localhost',
+        'PORT': '5432',
     }
 }
 

--- a/bewelder_redesign/settings.py
+++ b/bewelder_redesign/settings.py
@@ -37,6 +37,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    'haystack',
+
     'mainapp',
     'users',
     'resumes',
@@ -94,6 +97,14 @@ DATABASES = {
         'HOST': 'localhost',
         'PORT': '5432',
     }
+}
+
+# Haystack
+# https://django-haystack.readthedocs.io
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.simple_backend.SimpleEngine',
+    },
 }
 
 

--- a/bewelder_redesign/settings.py
+++ b/bewelder_redesign/settings.py
@@ -103,9 +103,11 @@ DATABASES = {
 # https://django-haystack.readthedocs.io
 HAYSTACK_CONNECTIONS = {
     'default': {
-        'ENGINE': 'haystack.backends.simple_backend.SimpleEngine',
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': os.path.join(BASE_DIR, 'whoosh_index'),
     },
 }
+HAYSTACK_SEARCH_RESULTS_PER_PAGE = 5
 
 
 # Password validation

--- a/bewelder_redesign/urls.py
+++ b/bewelder_redesign/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('vacancies/', include('vacancies.urls', namespace='vacancies')),
     path('orgs/', include('orgs.urls', namespace='orgs')),
     path('resumes/', include('resumes.urls', namespace='resumes')),
+    path('search/', include('haystack.urls')),
     path('', include('mainapp.urls', namespace='mainapp'))
 ]
 if settings.DEBUG:

--- a/mainapp/templates/mainapp/index.html
+++ b/mainapp/templates/mainapp/index.html
@@ -21,7 +21,7 @@
                                     </div>
                                     <div class="col">
                                         Резюме:
-                                        <p>4580</p>
+                                        <p>{{ resumes_count }}</p>
                                     </div>
                                     <div class="col">
                                         Компаний:
@@ -35,7 +35,7 @@
                                     <div class="col-xl-8">
                                         <div class="row">
                                             <div class="col">
-                                                <button type="button" class="btn btn-secondary button-add my-2">Разместить резюме</button>
+                                                <a href="{% url 'resumes:resume_create' %}" class="btn btn-secondary button-add my-2">Разместить резюме</a>
                                             </div>
                                             <div class="col text-right">
                                                 <button type="button" class="btn btn-secondary button-add my-2">Разместить вакансию</button>

--- a/mainapp/templates/mainapp/index.html
+++ b/mainapp/templates/mainapp/index.html
@@ -95,6 +95,7 @@
     <div class="row justify-content-center">
         <div class="col">
             <h3>Новые резюме</h3>
+            {% include 'components/resume_search_form.html' %}
             {% for resume in resumes %}
             {% include 'components/resume_short.html' %}
             {% endfor %}

--- a/mainapp/templates/mainapp/settings.html
+++ b/mainapp/templates/mainapp/settings.html
@@ -24,8 +24,8 @@
         <h4>Ваше резюме</h4>
         <hr>
         {% include 'components/resume_full.html' %}
-        <a href="{% url 'resumes:resume_update' %}" class="btn
-        btn-outline-success">Обновить резюме</a>
+        <a href="{% url 'resumes:resume_update' %}" class="btn btn-outline-success">Обновить резюме</a>
+        <a href="{% url 'resumes:resume_delete' %}" class="btn btn-outline-danger">Удалить резюме</a>
     </div>
     {% else %}
     <div class="my-5">

--- a/mainapp/templates/mainapp/settings.html
+++ b/mainapp/templates/mainapp/settings.html
@@ -13,8 +13,8 @@
             {{ user.date_of_birth|default:'' }}
         </p>
         <div class="mt-3">
-            <a href="{% url 'users:profile_update' %}" class="btn btn-outline-success">Изменить данные</a>
-            <a href="{% url 'users:password_change' %}" class="btn btn-outline-secondary">Сменить пароль</a>
+            <a href="{% url 'users:profile_update' %}" class="btn btn-outline-success my-1">Изменить данные</a>
+            <a href="{% url 'users:password_change' %}" class="btn btn-outline-secondary my-1">Сменить пароль</a>
         </div>
         
     </div>
@@ -29,7 +29,7 @@
     </div>
     {% else %}
     <div class="my-5">
-        <a href="{% url 'resumes:resume_create' %}">Создать резюме</a>
+        <a href="{% url 'resumes:resume_create' %}" class="btn btn-success btn-lg btn-block">Создать резюме</a>
     </div>
     {% endif %}
     {% endwith %}

--- a/mainapp/templates/mainapp/settings.html
+++ b/mainapp/templates/mainapp/settings.html
@@ -12,8 +12,11 @@
             {{ user.email }}<br>
             {{ user.date_of_birth|default:'' }}
         </p>
-        <a href="{% url 'users:profile_update' %}" class="btn
-        btn-outline-success mt-3">Изменить данные</a>
+        <div class="mt-3">
+            <a href="{% url 'users:profile_update' %}" class="btn btn-outline-success">Изменить данные</a>
+            <a href="{% url 'users:password_change' %}" class="btn btn-outline-secondary">Сменить пароль</a>
+        </div>
+        
     </div>
     {% with resume=user.resume %}
     {% if resume %}

--- a/mainapp/tests.py
+++ b/mainapp/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/mainapp/tests/test_views.py
+++ b/mainapp/tests/test_views.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from mixer.backend.django import mixer
+from resumes.models import Resume
+
+
+class HomePageViewTestCase(TestCase):
+    def test_home_page(self):
+        mixer.cycle(10).blend(Resume)
+
+        resp = self.client.get(reverse('mainapp:home'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('resumes', resp.context)
+        self.assertEqual(len(resp.context['resumes']), 5)
+
+        self.assertIn('resumes_count', resp.context)
+        self.assertEqual(resp.context['resumes_count'], 10)

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -14,7 +14,9 @@ class HomePageView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['resumes'] = Resume.objects.all()[:5]
+        resumes = Resume.objects.all()
+        context['resumes'] = resumes[:5]
+        context['resumes_count'] = resumes.count()
         return context
 
 

--- a/postgres_db_create.bash
+++ b/postgres_db_create.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+sudo -u postgres psql -v ON_ERROR_STOP=1 --username postgres <<-EOSQL
+    CREATE DATABASE bewgb_db;
+    CREATE USER bewgb_user WITH PASSWORD 'password';
+    ALTER ROLE bewgb_user SET client_encoding TO 'utf8';
+    ALTER ROLE bewgb_user SET default_transaction_isolation TO 'read committed';
+    ALTER ROLE bewgb_user SET timezone TO 'UTC';
+    GRANT ALL PRIVILEGES ON DATABASE bewgb_db TO bewgb_user;
+    ALTER USER bewgb_user CREATEDB;
+EOSQL

--- a/postgres_db_drop.bash
+++ b/postgres_db_drop.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+sudo -u postgres psql -v ON_ERROR_STOP=1 --username postgres <<-EOSQL
+    DROP DATABASE IF EXISTS bewgb_db;
+    DROP USER IF EXISTS bewgb_user;
+EOSQL

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ six==1.12.0               # via python-memcached
 mixer==6.1.3
 psycopg2-binary==2.7.7
 django-haystack==2.8.1
+Whoosh==2.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-memcached==1.59
 pytz==2018.9              # via django
 six==1.12.0               # via python-memcached
 mixer==6.1.3
+psycopg2-binary==2.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pytz==2018.9              # via django
 six==1.12.0               # via python-memcached
 mixer==6.1.3
 psycopg2-binary==2.7.7
+django-haystack==2.8.1

--- a/resumes/search_indexes.py
+++ b/resumes/search_indexes.py
@@ -1,0 +1,13 @@
+from haystack import indexes
+from resumes.models import Resume
+
+
+class ResumeIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True)
+    user = indexes.CharField(model_attr='user')
+    position = indexes.CharField(model_attr='position', null=True)
+    about = indexes.CharField(model_attr='about', null=True)
+    city = indexes.CharField(model_attr='city', null=True)
+
+    def get_model(self):
+        return Resume

--- a/resumes/templates/components/resume_search_form.html
+++ b/resumes/templates/components/resume_search_form.html
@@ -1,0 +1,9 @@
+<form action="{% url 'haystack_search' %}" method="get">
+    <div class="input-group my-3">
+        <input type="text" name='q' class="form-control" placeholder="Искать резюме" aria-label="Example text with button addon" aria-describedby="button-addon1">
+        <div class="input-group-append">
+            <button class="btn btn-success" type="submit" id="button-addon1">Найти</button>
+        </div>
+    </div>
+    <input type="checkbox" name="models" value="resumes.resume" checked hidden>
+</form>

--- a/resumes/templates/resumes/resume_confirm_delete.html
+++ b/resumes/templates/resumes/resume_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends 'mainapp/base.html' %}
+
+
+{% block content %}
+
+<div class="container my-5">
+    <h3>Удаление резюме</h3>
+    <form method="post">
+        {% csrf_token %}
+        <p>Вы уверены, что хотите удалить свое резюме?</p>
+        <input type=button value="Отмена" onClick="javascript:history.go(-1);" class="btn btn-outline-primary">
+        <input type="submit" value="Удалить" class="btn btn-danger">
+    </form>
+
+</div>
+
+
+{% endblock %}

--- a/resumes/templates/resumes/resume_form.html
+++ b/resumes/templates/resumes/resume_form.html
@@ -7,7 +7,7 @@
     <form method="post" class="my-3">
         {% csrf_token %}
         {% include 'includes/bootstrap_form.html' %}
-        <input type="submit" value="Создать" class="btn btn-success">
+        <input type="submit" value="Сохранить" class="btn btn-success">
     </form>
 </div>
 

--- a/resumes/templates/resumes/resume_list.html
+++ b/resumes/templates/resumes/resume_list.html
@@ -3,6 +3,7 @@
 {% block content %}
 <div class="container my-5">
     <h3 class="mb-5">Резюме</h3>
+    {% include 'components/resume_search_form.html' %}
     {% for resume in resumes %}
         {% include 'components/resume_short.html' %}
     {% empty %}

--- a/resumes/templates/search/indexes/resumes/resume_text.txt
+++ b/resumes/templates/search/indexes/resumes/resume_text.txt
@@ -1,0 +1,4 @@
+{{ object.position }}
+{{ object.user.get_full_name }}
+{{ object.city }}
+{{ object.about }}

--- a/resumes/templates/search/search.html
+++ b/resumes/templates/search/search.html
@@ -1,0 +1,37 @@
+{% extends 'mainapp/base.html' %}
+
+{% block content %}
+<div class="container my-5">
+    <h2>Поиск</h2>
+
+    <form method="get" action="." class="my-5">
+        {% include 'includes/bootstrap_form.html' %}
+        <input type="submit" value="Искать" class="btn btn-success">
+    </form>
+
+    {% if query %}
+        <h3>Результаты</h3>
+
+        {% for result in page.object_list %}
+            {% with result.object as resume %}
+                {% include 'components/resume_short.html' %}
+            {% endwith %}
+        {% empty %}
+            <p>Ничего не найдено.</p>
+        {% endfor %}
+
+        {% if page.has_previous or page.has_next %}
+            <div>
+                {% if page.has_previous %}
+                    <a href="?q={{ query }}&amp;page={{ page.previous_page_number }}">&laquo; Предыдущие</a>
+                {% endif %}
+                &#9679;
+                {% if page.has_next %}
+                    <a href="?q={{ query }}&amp;page={{ page.next_page_number }}">Следующие &raquo;</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+
+</div>
+{% endblock %}

--- a/resumes/templates/search/search.html
+++ b/resumes/templates/search/search.html
@@ -10,7 +10,7 @@
     </form>
 
     {% if query %}
-        <h3>Результаты</h3>
+        <h3>Результаты поиска</h3>
 
         {% for result in page.object_list %}
             {% with result.object as resume %}
@@ -21,13 +21,13 @@
         {% endfor %}
 
         {% if page.has_previous or page.has_next %}
-            <div>
+            <div class="my-5">
                 {% if page.has_previous %}
-                    <a href="?q={{ query }}&amp;page={{ page.previous_page_number }}">&laquo; Предыдущие</a>
+                    <a href="?q={{ query }}&amp;page={{ page.previous_page_number }}{% if request.GET.models %}&amp;models={{request.GET.models}}{% endif %}">&laquo; Предыдущие</a>
                 {% endif %}
                 &#9679;
                 {% if page.has_next %}
-                    <a href="?q={{ query }}&amp;page={{ page.next_page_number }}">Следующие &raquo;</a>
+                    <a href="?q={{ query }}&amp;page={{ page.next_page_number }}{% if request.GET.models %}&amp;models={{request.GET.models}}{% endif %}">Следующие &raquo;</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/resumes/tests/test_search.py
+++ b/resumes/tests/test_search.py
@@ -1,0 +1,60 @@
+import os
+
+from django.conf import settings
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from haystack.utils.loading import ConnectionHandler, UnifiedIndex
+from haystack import connections
+from mixer.backend.django import mixer
+from resumes.models import Resume
+from resumes.search_indexes import ResumeIndex
+
+TEST_INDEX = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': os.path.join(settings.BASE_DIR, 'whoosh_test_index'),
+    },
+}
+
+
+@override_settings(HAYSTACK_CONNECTIONS=TEST_INDEX)
+class ResumeSearchTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        mixer.cycle(5).blend(Resume, position='сварщик')
+        mixer.cycle(3).blend(Resume, position='инженер')
+
+        self.old_unified_index = connections['default']._index
+        self.ui = UnifiedIndex()
+        self.resume_index = ResumeIndex()
+        self.ui.build(indexes=[self.resume_index])
+
+        backend = connections['default'].get_backend()
+        backend.clear()
+        backend.update(self.resume_index, Resume.objects.all())
+
+    def tearDown(self):
+        connections['default']._index = self.old_unified_index
+        return super().tearDown()
+
+    def test_search_view(self):
+        resp = self.client.get(reverse('haystack_search'))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_search_query(self):
+        resp = self.client.get(reverse('haystack_search'), {'q': 'сварщик'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context[-1]['page'].object_list), 5)
+        self.assertEqual(resp.context[-1]['page'].object_list[0].content_type(), 'resumes.resume')
+
+        resp = self.client.get(reverse('haystack_search'), {'q': 'инженер'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context[-1]['page'].object_list), 3)
+        self.assertEqual(resp.context[-1]['page'].object_list[0].content_type(), 'resumes.resume')
+
+        resp = self.client.get(reverse('haystack_search'), {'q': 'директор'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context[-1]['page'].object_list), 0)

--- a/resumes/tests/test_views.py
+++ b/resumes/tests/test_views.py
@@ -30,6 +30,43 @@ class ResumeDetailTestCase(TestCase):
         self.assertEqual(resp.context.get('resume'), resume)
 
 
+class ResumeDeleteTestCase(TestCase):
+    def test_with_unauthorized(self):
+        resp = self.client.get(reverse('resumes:resume_delete'))
+        self.assertRedirects(
+            resp,
+            '{}?next={}'.format(reverse('users:login'), reverse('resumes:resume_delete'))
+        )
+
+    def test_get_confirmation_view(self):
+        user = mixer.blend(User)
+        resume = mixer.blend(Resume, user=user)
+        self.client.force_login(user)
+
+        resp = self.client.get(reverse('resumes:resume_delete'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, 'resumes/resume_confirm_delete.html')
+
+    def test_post(self):
+        user = mixer.blend(User)
+        resume = mixer.blend(Resume, user=user)
+        self.assertEqual(Resume.objects.count(), 1)
+
+        self.client.force_login(user)
+
+        resp = self.client.post(reverse('resumes:resume_delete'))
+        self.assertRedirects(resp, reverse('mainapp:settings'))
+        self.assertEqual(Resume.objects.count(), 0)
+        user.refresh_from_db()
+        self.assertFalse(user.is_seeker)
+
+    def test_delete_nonexistent_resume(self):
+        user = User.objects.create_user('foo@bar.com', 'password')
+        self.client.force_login(user)
+        resp = self.client.post(reverse('resumes:resume_delete'))
+        self.assertEqual(resp.status_code, 404)
+
+
 class ResumeCreateTestCase(TestCase):
     url_name = 'resumes:resume_create'
 

--- a/resumes/urls.py
+++ b/resumes/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('<int:pk>', views.ResumeDetail.as_view(), name='resume_detail'),
     path('create/', views.ResumeCreate.as_view(), name='resume_create'),
     path('update/', views.ResumeUpdate.as_view(), name='resume_update'),
+    path('delete/', views.ResumeDelete.as_view(), name='resume_delete'),
     path('', views.ResumeList.as_view(), name='resume_list'),
 
 ]

--- a/resumes/views.py
+++ b/resumes/views.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
-from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, DetailView, ListView, UpdateView, DeleteView
+from django.http import Http404
 
 from resumes.forms import ResumeForm
 from resumes.models import Resume
@@ -39,3 +41,14 @@ class ResumeUpdate(LoginRequiredMixin, UpdateView):
 
     def get_object(self, queryset=None):
         return self.request.user.resume
+
+
+class ResumeDelete(LoginRequiredMixin, DeleteView):
+    model = Resume
+    success_url = reverse_lazy('mainapp:settings')
+
+    def get_object(self, queryset=None):
+        user = self.request.user
+        if user.is_anonymous or not user.is_seeker:
+            raise Http404
+        return user.resume

--- a/users/templates/includes/bootstrap_form.html
+++ b/users/templates/includes/bootstrap_form.html
@@ -3,29 +3,51 @@
 {{ form.non_field_errors }}
 
 {% for field in form %}
-    <div class="form-group">
-        <label for="{{ field.id_for_label }}">
-            {{ field.label }}
-            {% if field.field.required %}*{% endif %}
-        </label>
-
-        {% if form.is_bound %}
-            {% if field.errors %}
-                {{ field|css_class:"form-control is-invalid" }}
-                <div class="invalid-feedback">
-                    {{ field.errors }}
+    {% if 'checkbox' in field.as_widget %}
+        
+        <div class="form-group">
+            {% for choice in field.field.choices %}
+                <div class="form-check">
+                    <label id="id_{{ field.id_for_label }}_{{ forloop.counter }}"
+                           class="form-check-label"
+                           for="id_{{ field.html_name }}_{{ forloop.counter }}">
+                        <input type="checkbox" class="form-check-input"
+                        {% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %}
+                            checked="checked"
+                        {% endif %}
+                            name="{{ field.html_name }}" 
+                            id="id_{{ field.html_name }}_{{ forloop.counter }}" 
+                            value="{{ choice.0 }}">
+                        {{ choice.1 }}
+                    </label>
                 </div>
-            {% else %}
-                {{ field|css_class:"form-control is-valid" }}
-            {% endif %}
-        {% else %}
-            {{ field|css_class:"form-control" }}
-        {% endif %}
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="form-group">
+            <label for="{{ field.id_for_label }}">
+                {{ field.label }}
+                {% if field.field.required %}*{% endif %}
+            </label>
 
-        {% if field.help_text %}
-            <small class="form-text text-muted">
-                {{ field.help_text|safe }}
-            </small>
-        {% endif %}
-    </div>
+            {% if form.is_bound %}
+                {% if field.errors %}
+                    {{ field|css_class:"form-control is-invalid" }}
+                    <div class="invalid-feedback">
+                        {{ field.errors }}
+                    </div>
+                {% else %}
+                    {{ field|css_class:"form-control is-valid" }}
+                {% endif %}
+            {% else %}
+                {{ field|css_class:"form-control" }}
+            {% endif %}
+
+            {% if field.help_text %}
+                <small class="form-text text-muted">
+                    {{ field.help_text|safe }}
+                </small>
+            {% endif %}
+        </div>
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
### Переход на postgres (описание для убунты)

Для установки postgres выполняем в терминале:

```
sudo apt update
sudo apt install libpq-dev postgresql postgresql-contrib
```

Ручная настройка и создание бд хорошо описана в этой [статье от digitalocean](https://www.digitalocean.com/community/tutorials/how-to-set-up-django-with-postgres-nginx-and-gunicorn-on-ubuntu-16-04) или на русском [здесь](https://pythonworld.ru/web/django-ubuntu1604.html). Только учтите, что данные для бд нужно будет взять из `settings.py` нашего проекта.

Но для простого и быстрого создания и удаления бд в postgres я создал два bash-скрипта. Для создания бд просто используйте команду:

```
$ bash postgres_db_create.bash
```

А если нужно быстро дропнуть бд, то используйте команду:

```
$ bash postgres_db_drop.bash
```

Эти скрипты должны работать, если postgres установлен с настройками по умолчанию.

### Поиск по резюме

Начальная версия поиска по резюме. Для его реализации использовал `django-haystack` (https://django-haystack.readthedocs.io/en/master/). А в качестве поискового движка взял `whoosh` (https://whoosh.readthedocs.io/en/latest/intro.html).

Поиск работает с некоторыми ограничениями. Например, если в строке поиска ввести:

```
сварщик москва
```

то поиск выдаст, как и ожидается, всех сварщиков по Москве. Однако, если ввести что-то вроде этого:

```
сварщики в Москве
```

то поиск ничего не выдаст. Эта проблема решаема несколькими способами, но это уже задача для одной из следующих итераций разработки.