### PR TITLE
Vacancies edit and delete

### DIFF
--- a/vacancies/templates/vacancies/update-vacancy.html
+++ b/vacancies/templates/vacancies/update-vacancy.html
@@ -1,0 +1,18 @@
+{% extends 'mainapp/base.html' %}
+
+{% block content %}
+<div class="cont-width-block">
+    <div class="m-5">
+        <h5>Вакансия {{ form.title }}</h5>
+        <h2>{{ user.get_full_name|title }}</h2>
+        <form method="post" class="my-3">
+            {% csrf_token %}
+            {{ form.media }}
+            {{ form.as_p }}
+
+            <input type="submit" value="Сохранить" class="btn btn-success">
+        </form>
+    </div>
+</div>
+
+{% endblock %}

--- a/vacancies/templates/vacancies/update-vacancy.html
+++ b/vacancies/templates/vacancies/update-vacancy.html
@@ -3,8 +3,8 @@
 {% block content %}
 <div class="cont-width-block">
     <div class="m-5">
-        <h5>Вакансия {{ form.title }}</h5>
-        <h2>{{ user.get_full_name|title }}</h2>
+        <h3>Пользователь: {{ user.get_full_name|title }}</h3>
+        <h3>Вакансия: {{ form.initial.title }}</h3>
         <form method="post" class="my-3">
             {% csrf_token %}
             {{ form.media }}

--- a/vacancies/templates/vacancies/vacancy_confirm_delete.html
+++ b/vacancies/templates/vacancies/vacancy_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends 'mainapp/base.html' %}
+
+
+{% block content %}
+
+<div class="container my-5">
+    <h3>Удаление вакансии {{ vacancy.title }}</h3>
+    <form method="post">
+        {% csrf_token %}
+        <p>Вы уверены, что хотите удалить эту вакансию?</p>
+        <input type=button value="Отмена" onClick="javascript:history.go(-1);" class="btn btn-outline-primary">
+        <input type="submit" name="Confirm" value="Удалить" class="btn btn-danger">
+    </form>
+
+</div>
+
+
+{% endblock %}

--- a/vacancies/tests.py
+++ b/vacancies/tests.py
@@ -213,8 +213,6 @@ class TestVacancyUpdateForm(TestCase):
             vacancy.naks_att_level.add(self.level1)
 
         self.vacancy = self.vacancies[random.randint(0, 9)]
-
-        print(model_to_dict(self.vacancy))
     
     def test_vacancy_created(self):
         vacancies = self.vacancies
@@ -222,10 +220,31 @@ class TestVacancyUpdateForm(TestCase):
         vacancies[0].naks_att_level.add(self.level1)
         self.assertTrue(self.level1 in vacancies[0].naks_att_level.all())
     
-    def test_vacancy_update_form_reachable_by_client(self):
+    def test_vacancy_update_form_reachable_by_id(self):
         self.client.force_login(self.user)
-        response = self.client.get(reverse('vacancies:update_vacancy', kwargs={'pk': self.vacancy.id}))
+        response = self.client.get(reverse('vacancies:vacancy_update', kwargs={'pk': self.vacancy.id}))
         self.assertTrue(response.status_code, 200)
-        
+        self.assertTrue(isinstance(response.context['form'], VacancyForm))
+        self.assertTrue(response.context['form']['title'].value()==self.vacancy.title)
 
+    def test_vacancy_udpate_form_can_save_data(self):
+        self.client.force_login(self.user)
+        update_url = reverse('vacancies:vacancy_update', kwargs={'pk': self.vacancy.id})
+        response = self.client.get(update_url)
+        form = response.context['form']
+        data = form.initial
+        print(data)
+        data['title'] = 'changed_title'
+        response = self.client.post(update_url, data)
 
+        response = self.client.get(update_url)
+        self.assertEqual(response.context['form'].initial['title'], 'changed_title')
+
+        # if vacancy_form.is_valid():
+        #     vacancy = vacancy_form.save()
+        #     self.assertEquals(vacancy.title==self.vacancy.title)
+        # else:
+        #     print(vacancy_form.errors)
+        #     self.fail('vacancy_form is not valid')
+        # self.client.post('/vacancies/update/{}'.format(self.vacancy.id), {'title': 'blablabla'})
+        # self.assertTrue(self.vacancy.title=='blablabla')

--- a/vacancies/tests.py
+++ b/vacancies/tests.py
@@ -228,23 +228,26 @@ class TestVacancyUpdateForm(TestCase):
         self.assertTrue(response.context['form']['title'].value()==self.vacancy.title)
 
     def test_vacancy_udpate_form_can_save_data(self):
+        #Авторизуемся
         self.client.force_login(self.user)
+        #Получаем ссылку для тестовых данных
         update_url = reverse('vacancies:vacancy_update', kwargs={'pk': self.vacancy.id})
+        #Переходим по ссылке
         response = self.client.get(update_url)
+        #Берем из формы данные
         form = response.context['form']
         data = form.initial
-        print(data)
+        #Меняем данные
         data['title'] = 'changed_title'
+        data['salary_max'] = 400
+        data['naks_att_level'] = self.level1.id
+        #Делаем пост с измененными данными
         response = self.client.post(update_url, data)
-
+        #Проверяем редирект после отправки данных
+        self.assertRedirects(response, reverse('mainapp:settings'))
+        #Еще раз заходим по ссылке
         response = self.client.get(update_url)
+        #Проверяем, что измененные данные в форме
         self.assertEqual(response.context['form'].initial['title'], 'changed_title')
-
-        # if vacancy_form.is_valid():
-        #     vacancy = vacancy_form.save()
-        #     self.assertEquals(vacancy.title==self.vacancy.title)
-        # else:
-        #     print(vacancy_form.errors)
-        #     self.fail('vacancy_form is not valid')
-        # self.client.post('/vacancies/update/{}'.format(self.vacancy.id), {'title': 'blablabla'})
-        # self.assertTrue(self.vacancy.title=='blablabla')
+        self.assertEqual(response.context['form'].initial['salary_max'], 400)
+        self.assertTrue(self.level1 in response.context['form'].initial['naks_att_level'])

--- a/vacancies/urls.py
+++ b/vacancies/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     path('list/', vacancies.vacancies_list, name='list'),
     path('new/', vacancies.add_new_vacancy, name='vacancy_create'),
     path('update/<slug:pk>', vacancies.vacancy_update, name='vacancy_update'),
-    path('delete/<slug:pk>', vacancies.delete_vacancy, name='vacancy_delete'),
+    path('delete/<slug:pk>', vacancies.vacancy_delete, name='vacancy_delete'),
 ]

--- a/vacancies/urls.py
+++ b/vacancies/urls.py
@@ -6,6 +6,6 @@ app_name = 'vacancies'
 urlpatterns = [
     path('list/', vacancies.vacancies_list, name='list'),
     path('new/', vacancies.add_new_vacancy, name='vacancy_create'),
-    path('update/<slug:pk>', vacancies.update_vacancy, name='vacancy_update'),
+    path('update/<slug:pk>', vacancies.vacancy_update, name='vacancy_update'),
     path('delete/<slug:pk>', vacancies.delete_vacancy, name='vacancy_delete'),
 ]

--- a/vacancies/views.py
+++ b/vacancies/views.py
@@ -65,8 +65,17 @@ def vacancy_update(request, pk):
     }
     return render(request, 'vacancies/update-vacancy.html', content)
 
-def delete_vacancy(request, pk):
-    pass
+def vacancy_delete(request, pk):
+    vacancy = get_object_or_404(Vacancy, pk=pk)
+    if request.method == "POST":
+        if 'Confirm' in request.POST:
+            vacancy.delete()
+            return HttpResponseRedirect(reverse('mainapp:settings'))
+    content = {
+        'vacancy': vacancy
+    }
+
+    return render(request, 'vacancies/vacancy_confirm_delete.html', content)
 
 
 

--- a/vacancies/views.py
+++ b/vacancies/views.py
@@ -49,8 +49,16 @@ def add_new_vacancy(request):
 
 def vacancy_update(request, pk):
     # instance = get_object_or_404(Vacancy, id=pk)
-    instance = Vacancy.objects.get(id=pk)
+    instance = get_object_or_404(Vacancy, pk=pk)
     form = VacancyForm(request.POST or None, instance=instance)
+    if request.method == 'POST':
+        if form.is_valid():
+            instance = form.save(commit=False)
+            instance.user = request.user
+            instance.save()
+            return HttpResponseRedirect(reverse('mainapp:settings'))
+        else:
+            print('ERRORS', form.errors.as_data())
     content = {
         'title': 'Обновление вакансии',
         'form': form,

--- a/vacancies/views.py
+++ b/vacancies/views.py
@@ -8,6 +8,7 @@ from .models import Vacancy, Level
 from .forms import VacancyForm
 # from orgs.forms import EmployerForm, RegionForm, CityForm
 from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404
 # from django.forms.formsets import formset_factory
 # Create your views here.
 
@@ -46,8 +47,15 @@ def add_new_vacancy(request):
     }
     return render(request, 'vacancies/add-new-vacancy.html', content)
 
-def update_vacancy(request, pk):
-    pass
+def vacancy_update(request, pk):
+    # instance = get_object_or_404(Vacancy, id=pk)
+    instance = Vacancy.objects.get(id=pk)
+    form = VacancyForm(request.POST or None, instance=instance)
+    content = {
+        'title': 'Обновление вакансии',
+        'form': form,
+    }
+    return render(request, 'vacancies/update-vacancy.html', content)
 
 def delete_vacancy(request, pk):
     pass


### PR DESCRIPTION
Этот пулл реквест добавляет форму для редактирования и удаления вакансий в личном кабинете пользователя. 
Для тестов использовал дополнительную библиотеку [model_mommy](https://model-mommy.readthedocs.io/en/latest/index.html). Чтобы тесты прошли надо предварительно установить 
`pip install model_mommy`
Я использовал эту библиотеку потому что в миксере у меня были проблемы с установкой M2M отношений vacancies -> level при тестировании. 
Тесты на обновление и удаление вакансий добавил. 